### PR TITLE
Initial implementation of RxScala Observable interface for result sets and queries

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -151,6 +151,7 @@ object phantom extends Build {
       "com.typesafe.play"            %% "play-iteratees"                    % "2.2.0",
       "joda-time"                    %  "joda-time"                         % "2.3",
       "org.joda"                     %  "joda-convert"                      % "1.6",
+      "com.netflix.rxjava"           %  "rxjava-scala"                      % "0.17.4",
       "com.datastax.cassandra"       %  "cassandra-driver-core"             % datastaxDriverVersion exclude("log4j", "log4j")
 
     )


### PR DESCRIPTION
Observables from RxJava/RxScala offer an alternative to Futures and Play Iteratees for result sets and queries. Extensive support for collection methods allows for operations such as `select.observe.skip(10).take(20).groupBy(_.name)`. See https://github.com/Netflix/RxJava/wiki for more details on Rx and Observables.

This is an initial implementation and has not been tested extensively. I'm submitting this pull request to see if there's any interest in the Rx approach.
