### PR TITLE
Use Scala reflection API to discover CassandraTable columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,8 @@ Copyright 2013 WhiskLabs, Copyright 2013 - 2014 newzly.
 Contributions
 =============
 
+* Bartosz Jankiewicz (@bjankie1)
+
 Contributions are most welcome! 
 
 To contribute, simply submit a "Pull request" via GitHub.

--- a/phantom-dsl/src/main/scala/com/newzly/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/newzly/phantom/CassandraTable.scala
@@ -15,8 +15,9 @@
  */
 package com.newzly.phantom
 
-import java.lang.reflect.Method
 import scala.collection.mutable.{ ListBuffer, ArrayBuffer }
+import scala.reflect.runtime.{ universe => ru}
+import scala.reflect.runtime.{ currentMirror => cm }
 import scala.util.Try
 import org.slf4j.LoggerFactory
 import com.datastax.driver.core.Row
@@ -126,42 +127,21 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
     })
   }
 
-  private[this] def isField(m: Method) = {
-    val ret = !m.isSynthetic && classOf[AbstractColumn[_]].isAssignableFrom(m.getReturnType)
-    ret
-  }
-
-  private[this] def introspect(rec: CassandraTable[T, R], methods: Array[Method])(f: (Method, AbstractColumn[_]) => Any): Unit = {
-
-    // find all the potential fields
-    val potentialFields = methods.filter(isField)
-
-    // any fields with duplicate names get put into a List
-    val fullMap = potentialFields.foldLeft[Map[String, List[Method]]](Map()) {
-      case (map, method) => val name = method.getName
-        order += method.getName
-        map + (name -> (method :: map.getOrElse(name, Nil)))
+  private[this] def introspect(f: (String, AbstractColumn[_]) => Any): Unit = {
+    val im = cm.reflect(this)
+    val members = im.symbol.selfType.members
+    val objectMembers = members.filter(_.isModule).map(_.asModule)
+    val metaDataMembers = objectMembers.filter(_.moduleClass.asClass.toType.<:<(ru.typeOf[AbstractColumn[_]]))
+    metaDataMembers.foreach { m =>
+      f(m.name.decoded, im.reflectModule(m).instance.asInstanceOf[AbstractColumn[_]])
     }
-
-    // sort each list based on having the most specific type and use that method
-    val realMeth = fullMap.values.map(_.sortWith {
-      case (a, b) => !a.getReturnType.isAssignableFrom(b.getReturnType)
-    }).map(_.head)
-
-    for (v <- realMeth) {
-      v.invoke(rec) match {
-        case mf: AbstractColumn[_]  => f(v, mf)
-        case _ =>
-      }
-    }
-
   }
 
   this.runSafe {
     val tArray = new ListBuffer[FieldHolder]
-    introspect(this, this.getClass.getSuperclass.getMethods) {
-      case (v, mf) =>
-        tArray += FieldHolder(mf.name, mf)
+    introspect {
+      case (name, ac) =>
+        tArray += FieldHolder(name, ac)
     }
 
   val sorted = tArray.sortWith((field1, field2) => order.indexWhere(field1.name == _ ) < order.indexWhere(field2.name == _ ))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,11 +12,18 @@ object phantom extends Build {
   val scalatestVersion = "2.1.0"
   val finagleVersion = "6.10.0"
   val scroogeVersion = "3.11.2"
-  val thriftVersion = "0.5.0"
+  val thriftVersion = "0.8.0"
+
+  val thriftLibs = Seq(
+    "org.apache.thrift" % "libthrift" % thriftVersion intransitive()
+  )
+  val scroogeLibs = thriftLibs ++ Seq(
+    "com.twitter" %% "scrooge-runtime" % scroogeVersion
+  )
 
   val sharedSettings: Seq[sbt.Project.Setting[_]] = Seq(
     organization := "com.newzly",
-    version := "0.5.0",
+    version := "0.4.5",
     scalaVersion := "2.10.4",
     resolvers ++= Seq(
       "Typesafe repository snapshots" at "http://repo.typesafe.com/typesafe/snapshots/",
@@ -45,7 +52,7 @@ object phantom extends Build {
      )
   ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings
 
-  val publishSettings : Seq[sbt.Project.Setting[_]] = Seq(
+  val mavenPublishSettings : Seq[sbt.Project.Setting[_]] = Seq(
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     publishMavenStyle := true,
     publishTo <<= version.apply{
@@ -85,7 +92,7 @@ object phantom extends Build {
         </developers>
   )
 
-  val mavenPublishSettings : Seq[sbt.Project.Setting[_]] = Seq(
+  val publishSettings : Seq[sbt.Project.Setting[_]] = Seq(
       publishTo := Some("newzly releases" at "http://maven.newzly.com/repository/internal"),
       credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
       publishMavenStyle := true,
@@ -145,8 +152,8 @@ object phantom extends Build {
       "com.typesafe.play"            %% "play-iteratees"                    % "2.2.0",
       "joda-time"                    %  "joda-time"                         % "2.3",
       "org.joda"                     %  "joda-convert"                      % "1.6",
-      "com.datastax.cassandra"       %  "cassandra-driver-core"             % datastaxDriverVersion exclude("log4j", "log4j")
-
+      "com.datastax.cassandra"       %  "cassandra-driver-core"             % datastaxDriverVersion exclude("log4j", "log4j"),
+      "org.scala-lang"               %  "scala-reflect"                     % "2.10.4"
     )
   )
 
@@ -232,7 +239,6 @@ object phantom extends Build {
     )
   ).settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang"           %  "scala-compiler"                    % "2.10.4",
       "com.newzly"               %% "util-testing"                      % newzlyUtilVersion     % "provided"
     )
   ).dependsOn(


### PR DESCRIPTION
I have replaced Java reflection API with Scala one. It solves an issue I have faced when working with the API.
The problem with Java API appears when added a construct parameter alone. E.g.

```
sealed class ExampleRecord(client: CassandraClient)
  extends CassandraTable[ExampleRecord, Example]  {
```
