### PR TITLE
Proper handling of null values

### DIFF
--- a/phantom-dsl/src/main/scala/com/newzly/phantom/CassandraType.scala
+++ b/phantom-dsl/src/main/scala/com/newzly/phantom/CassandraType.scala
@@ -43,49 +43,56 @@ object CassandraPrimitive {
 
     val cassandraType = "int"
     def cls: Class[_] = classOf[java.lang.Integer]
-    def fromRow(row: Row, name: String): Option[Int] = Try(row.getInt(name)).toOption
+    def fromRow(row: Row, name: String): Option[Int] =
+      if (row.isNull(name)) None else Try(row.getInt(name)).toOption
   }
 
   implicit object FloatIsCassandraPrimitive extends CassandraPrimitive[Float] {
 
     val cassandraType = "float"
     def cls: Class[_] = classOf[java.lang.Float]
-    def fromRow(row: Row, name: String): Option[Float] = Try(row.getFloat(name)).toOption
+    def fromRow(row: Row, name: String): Option[Float] =
+      if (row.isNull(name)) None else Try(row.getFloat(name)).toOption
   }
 
   implicit object LongIsCassandraPrimitive extends CassandraPrimitive[Long] {
 
     val cassandraType = "bigint"
     def cls: Class[_] = classOf[java.lang.Long]
-    def fromRow(row: Row, name: String): Option[Long] = Try(row.getLong(name)).toOption
+    def fromRow(row: Row, name: String): Option[Long] =
+      if (row.isNull(name)) None else Try(row.getLong(name)).toOption
   }
 
   implicit object StringIsCassandraPrimitive extends CassandraPrimitive[String] {
 
     val cassandraType = "text"
     def cls: Class[_] = classOf[java.lang.String]
-    def fromRow(row: Row, name: String): Option[String] = Try(row.getString(name)).toOption
+    def fromRow(row: Row, name: String): Option[String] =
+      if (row.isNull(name)) None else Try(row.getString(name)).toOption
   }
 
   implicit object DoubleIsCassandraPrimitive extends CassandraPrimitive[Double] {
 
     val cassandraType = "double"
     def cls: Class[_] = classOf[java.lang.Double]
-    def fromRow(row: Row, name: String): Option[Double] = Try(row.getDouble(name)).toOption
+    def fromRow(row: Row, name: String): Option[Double] =
+      if (row.isNull(name)) None else Try(row.getDouble(name)).toOption
   }
 
   implicit object DateIsCassandraPrimitive extends CassandraPrimitive[Date] {
 
     val cassandraType = "timestamp"
     def cls: Class[_] = classOf[Date]
-    def fromRow(row: Row, name: String): Option[Date] = Try(row.getDate(name)).toOption
+    def fromRow(row: Row, name: String): Option[Date] =
+      if (row.isNull(name)) None else Try(row.getDate(name)).toOption
   }
 
   implicit object DateTimeisCassandraPrimitive extends CassandraPrimitive[DateTime] {
     val cassandraType = "timestamp"
     def cls: Class[_] = classOf[org.joda.time.DateTime]
     override def toCType(v: org.joda.time.DateTime): AnyRef = v.toDate.asInstanceOf[AnyRef]
-    def fromRow(row: Row, name: String): Option[DateTime] = Try(new DateTime(row.getDate(name))).toOption
+    def fromRow(row: Row, name: String): Option[DateTime] =
+      if (row.isNull(name)) None else Try(new DateTime(row.getDate(name))).toOption
   }
 
 
@@ -93,35 +100,40 @@ object CassandraPrimitive {
 
     val cassandraType = "boolean"
     def cls: Class[_] = classOf[Boolean]
-    def fromRow(row: Row, name: String): Option[Boolean] = Try(row.getBool(name)).toOption
+    def fromRow(row: Row, name: String): Option[Boolean] =
+      if (row.isNull(name)) None else  Try(row.getBool(name)).toOption
   }
 
   implicit object UUIDIsCassandraPrimitive extends CassandraPrimitive[UUID] {
 
     val cassandraType = "uuid"
     def cls: Class[_] = classOf[UUID]
-    def fromRow(row: Row, name: String): Option[UUID] = Try(row.getUUID(name)).toOption
+    def fromRow(row: Row, name: String): Option[UUID] =
+      if (row.isNull(name)) None else Try(row.getUUID(name)).toOption
   }
 
   implicit object BigDecimalCassandraPrimitive extends CassandraPrimitive[BigDecimal] {
 
     val cassandraType = "decimal"
     def cls: Class[_] = classOf[BigDecimal]
-    def fromRow(row: Row, name: String): Option[BigDecimal] = Try(BigDecimal(row.getDecimal(name))).toOption
+    def fromRow(row: Row, name: String): Option[BigDecimal] =
+      if (row.isNull(name)) None else Try(BigDecimal(row.getDecimal(name))).toOption
   }
 
   implicit object InetAddressCassandraPrimitive extends CassandraPrimitive[InetAddress] {
 
     val cassandraType = "inet"
     def cls: Class[_] = classOf[InetAddress]
-    def fromRow(row: Row, name: String): Option[InetAddress] = Try(row.getInet(name)).toOption
+    def fromRow(row: Row, name: String): Option[InetAddress] =
+      if (row.isNull(name)) None else Try(row.getInet(name)).toOption
   }
 
   implicit object BigIntCassandraPrimitive extends CassandraPrimitive[BigInt] {
 
     val cassandraType = "varint"
     def cls: Class[_] = classOf[BigInt]
-    def fromRow(row: Row, name: String): Option[BigInt] = Try(BigInt(row.getVarint(name))).toOption
+    def fromRow(row: Row, name: String): Option[BigInt] =
+      if (row.isNull(name)) None else Try(BigInt(row.getVarint(name))).toOption
   }
 
 }

--- a/phantom-test/src/test/scala/com/newzly/phantom/dsl/crud/SelectOptionalTest.scala
+++ b/phantom-test/src/test/scala/com/newzly/phantom/dsl/crud/SelectOptionalTest.scala
@@ -1,0 +1,59 @@
+package com.newzly.phantom.dsl.crud
+
+import scala.concurrent.blocking
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.SpanSugar._
+import com.newzly.phantom.Implicits._
+import com.newzly.phantom.tables.{ OptionalPrimitive, OptionalPrimitives }
+import com.newzly.util.testing.AsyncAssertionsHelper._
+import com.newzly.util.testing.cassandra.BaseTest
+
+class SelectOptionalTest extends BaseTest {
+  implicit val s: PatienceConfiguration.Timeout = timeout(10 seconds)
+  val keySpace: String = "selectOptionalTest"
+
+  override def beforeAll(): Unit = {
+    blocking {
+      super.beforeAll()
+      OptionalPrimitives.insertSchema()
+    }
+  }
+
+  "Selecting the whole row" should "work fine when optional value defined" in {
+    checkRow(OptionalPrimitive.sample)
+  }
+
+  it should "work fine when optional value is empty" in {
+    checkRow(OptionalPrimitive.none)
+  }
+
+  private def checkRow(row: OptionalPrimitive) {
+    val rcp =  OptionalPrimitives.insert
+      .value(_.pkey, row.pkey)
+      .value(_.string, row.string)
+      .value(_.long, row.long)
+      .value(_.boolean, row.boolean)
+      .value(_.bDecimal, row.bDecimal)
+      .value(_.double, row.double)
+      .value(_.float, row.float)
+      .value(_.inet, row.inet)
+      .value(_.int, row.int)
+      .value(_.date, row.date)
+      .value(_.uuid, row.uuid)
+      .value(_.bi, row.bi).future() flatMap {
+      _ => {
+        for {
+          a <- OptionalPrimitives.select.fetch
+          b <- OptionalPrimitives.select.where(_.pkey eqs row.pkey).one
+        } yield (a contains row, b.get === row)
+      }
+    }
+
+    rcp successful {
+      r => {
+        assert(r._1)
+        assert(r._2)
+      }
+    }
+  }
+}

--- a/phantom-test/src/test/scala/com/newzly/phantom/tables/OptionalPrimitives.scala
+++ b/phantom-test/src/test/scala/com/newzly/phantom/tables/OptionalPrimitives.scala
@@ -1,0 +1,85 @@
+package com.newzly.phantom.tables
+
+import com.datastax.driver.core.Row
+import com.newzly.phantom.CassandraTable
+import com.newzly.phantom.helper.{ ModelSampler, TestSampler}
+import com.newzly.phantom.Implicits._
+import com.newzly.util.testing.Sampler
+import java.net.InetAddress
+import java.util.{UUID, Date}
+
+case class OptionalPrimitive(
+                      pkey: String,
+                      string: Option[String],
+                      long: Option[Long],
+                      boolean: Option[Boolean],
+                      bDecimal: Option[BigDecimal],
+                      double: Option[Double],
+                      float: Option[Float],
+                      inet: Option[java.net.InetAddress],
+                      int: Option[Int],
+                      date: Option[java.util.Date],
+                      uuid: Option[java.util.UUID],
+                      bi: Option[BigInt]
+                      )
+
+object OptionalPrimitive extends ModelSampler[OptionalPrimitive] {
+  def sample: OptionalPrimitive = {
+    OptionalPrimitive(
+      Sampler.getARandomString,
+      Some(Sampler.getARandomString),
+      Some(Sampler.getARandomInteger().toLong),
+      Some(false),
+      Some(BigDecimal(Sampler.getARandomInteger())),
+      Some(Sampler.getARandomInteger().toDouble),
+      Some(Sampler.getARandomInteger().toFloat),
+      Some(InetAddress.getByName("127.0.0.1")),
+      Some(Sampler.getARandomInteger()),
+      Some(new Date()),
+      Some(UUID.randomUUID()),
+      Some(BigInt(Sampler.getARandomInteger()))
+    )
+  }
+
+  def none: OptionalPrimitive = {
+    OptionalPrimitive(
+      Sampler.getARandomString,
+      None, None, None, None, None, None, None, None, None, None, None
+    )
+  }
+}
+
+sealed class OptionalPrimitives extends CassandraTable[OptionalPrimitives, OptionalPrimitive] {
+  override def fromRow(r: Row): OptionalPrimitive = {
+    OptionalPrimitive(pkey(r), string(r), long(r), boolean(r), bDecimal(r), double(r), float(r), inet(r),
+      int(r), date(r), uuid(r), bi(r))
+  }
+
+  object pkey extends StringColumn(this) with PartitionKey[String]
+
+  object string extends OptionalStringColumn(this)
+
+  object long extends OptionalLongColumn(this)
+
+  object boolean extends OptionalBooleanColumn(this)
+
+  object bDecimal extends OptionalBigDecimalColumn(this)
+
+  object double extends OptionalDoubleColumn(this)
+
+  object float extends OptionalFloatColumn(this)
+
+  object inet extends OptionalInetAddressColumn(this)
+
+  object int extends OptionalIntColumn(this)
+
+  object date extends OptionalDateColumn(this)
+
+  object uuid extends OptionalUUIDColumn(this)
+
+  object bi extends OptionalBigIntColumn(this)
+}
+
+object OptionalPrimitives extends OptionalPrimitives with TestSampler[OptionalPrimitives, OptionalPrimitive] {
+  override val tableName = "OptionalPrimitives"
+}


### PR DESCRIPTION
When optional value is empty phantom insert 'nulls'. However when it reads value back in case of primitive types (int, boolean) it will end up with Some('default primitive value in JVM'). For OptionalIntColumn it will be Some(0), for OptionalBooleanColumn it will be Some(false), etc. For non-primitive types (string for example) it reads Some(null).
