### PR TITLE
Fixed index naming to prevent index name collisions

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
@@ -185,7 +185,7 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
 
   def createIndexes(): Seq[String] = {
     secondaryKeys.map(k => {
-      val query = s"CREATE INDEX IF NOT EXISTS ${k.name} ON $tableName (${k.name});"
+      val query = s"CREATE INDEX IF NOT EXISTS ${tableName}_${k.name} ON $tableName (${k.name});"
       logger.info("Auto-generating CQL queries for secondary indexes")
       logger.info(query)
       query


### PR DESCRIPTION
Phantom gets column name for index name. It causes error `Duplicate index name %columnName%` when using Index on columns in different tables with the same name.
