### PR TITLE
Fix table logging to respect hierachy

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
@@ -49,7 +49,10 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
 
   def columns: MutableArrayBuffer[AbstractColumn[_]] = _columns
 
-  lazy val logger = LoggerFactory.getLogger(tableName)
+  lazy val logger = {
+    val klass = getClass.getName.stripSuffix("$")
+    LoggerFactory.getLogger(klass)
+  }
 
   def tableName: String = _name
 


### PR DESCRIPTION
Currently the logging for the CassandraTable class blithely takes the
name of the table as the name for the logger. This is undesirable for a
number of reasons most salient being:
- We are potentially trampling on other peoples namespace and logging
  hierachy
- We make it impossible to silence all logging on tables to a custom log
  level without adding an explicit directive for each table name

This commit fixes both these issues by simply taking the class name.
