### PR TITLE
Feature/improve enumerator

### DIFF
--- a/phantom-dsl/src/test/scala/com/websudos/phantom/iteratee/IterateeBenchmark.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/iteratee/IterateeBenchmark.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 websudos ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.websudos.phantom.iteratee
+
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.{ Await, Future }
+import scala.concurrent
+// import scala.concurrent.duration.DurationInt
+
+import org.scalameter.api.{ Gen => MeterGen, gen => _, _ }
+import org.scalatest.Matchers
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.SpanSugar._
+
+import com.websudos.phantom.Implicits._
+import com.websudos.phantom.tables.{ PrimitivesJoda, JodaRow }
+import com.websudos.phantom.testing.TestZookeeperConnector
+import com.websudos.util.testing._
+
+
+class IterateeBenchmark extends PerformanceTest.Quickbenchmark
+  with TestZookeeperConnector {
+
+  PrimitivesJoda.insertSchema()
+  val fs = for {
+    step <- 1 to 3
+    rows = Iterator.fill(10000)(gen[JodaRow])
+
+    batch = rows.foldLeft(new BatchStatement())((b, row) => {
+      val statement = PrimitivesJoda.insert
+        .value(_.pkey, row.pkey)
+        .value(_.intColumn, row.int)
+        .value(_.timestamp, row.bi)
+      b.add(statement)
+    })
+    w = batch.future()
+    f = w map (_ => println(s"step $step has succeed") )
+    r = Await.result(f, 200 seconds)
+  } yield f map (_ => r)
+
+  Await.ready(Future.sequence(fs), 20 seconds)
+
+  val sizes: MeterGen[Int] = MeterGen.range("size")(10000, 30000, 10000)
+
+  performance of "Enumerator" in {
+    measure method "enumerator" in {
+      using(sizes) in {
+        size => Await.ready(PrimitivesJoda.select.limit(size).fetchEnumerator run Iteratee.forEach { r => }, 10 seconds)
+      }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ object phantom extends Build {
   val scroogeVersion = "3.15.0"
   val thriftVersion = "0.9.1"
   val scalatraVersion = "2.2.2"
-  val PlayVersion = "2.2.0"
+  val PlayVersion = "2.3.0"
 
   val publishUrl = "http://maven.websudos.co.uk"
 
@@ -126,8 +126,9 @@ object phantom extends Build {
     name := "phantom-dsl",
     fork := true,
     testOptions in Test += Tests.Argument("-oF"),
-    logBuffered in Test := true,
+    logBuffered in Test := false,
     testOptions in Test := Seq(Tests.Filter(s => s.indexOf("IterateeBig") == -1)),
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     concurrentRestrictions in Test := Seq(
       Tags.limit(Tags.ForkedTestGroup, 4)
     ),
@@ -140,7 +141,8 @@ object phantom extends Build {
       "com.datastax.cassandra"       %  "cassandra-driver-core"             % datastaxDriverVersion,
       "org.scalacheck"               %% "scalacheck"                        % "1.11.4"                  % "test, provided",
       "com.websudos"                 %% "util-testing"                      % UtilVersion               % "provided",
-      "net.liftweb"                  %% "lift-json"                         % "2.6-M4"                  % "test, provided"
+      "net.liftweb"                  %% "lift-json"                         % "2.6-M4"                  % "test, provided",
+      "com.storm-enroute"            %% "scalameter"                        % "0.6"                     % "test"
     )
   ).dependsOn(
     phantomTesting % "test, provided"


### PR DESCRIPTION
Improves enumerator code in a couple of ways, see commit message for details. I have added a small benchmark. These are the results from my machine.
Before:

```
[info] Repetitions ended.
[info] ::Benchmark Enumerator.enumerator::
[info] cores: 4
[info] hostname: greyskull
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.65-b04
[info] os-arch: amd64
[info] os-name: Linux
[info] Parameters(size -> 10000): 283.25991
[info] Parameters(size -> 20000): 578.425475
[info] Parameters(size -> 30000): 857.977712
```

After:

```
[info] Repetitions ended.
[info] ::Benchmark Enumerator.enumerator::
[info] cores: 4
[info] hostname: greyskull
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.65-b04
[info] os-arch: amd64
[info] os-name: Linux
[info] Parameters(size -> 10000): 207.606342
[info] Parameters(size -> 20000): 375.515308
[info] Parameters(size -> 30000): 564.428892
```

Which I think is a decent improvement
