### PR TITLE
generate_predictable_index_name

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/serializers/CreateQueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/serializers/CreateQueryBuilder.scala
@@ -185,6 +185,7 @@ private[builder] class CreateTableBuilder extends CompactionQueryBuilder with Co
   def index(table: String, keySpace: String, column: String): CQLQuery = {
     CQLQuery(CQLSyntax.create).forcePad.append(CQLSyntax.index)
       .forcePad.append(CQLSyntax.ifNotExists)
+      .forcePad.append(s"${table}_${column}_idx")
       .forcePad.append(CQLSyntax.On)
       .forcePad.append(QueryBuilder.keyspace(keySpace, table))
       .wrapn(column)
@@ -203,6 +204,7 @@ private[builder] class CreateTableBuilder extends CompactionQueryBuilder with Co
   def mapIndex(table: String, keySpace: String, column: String): CQLQuery = {
     CQLQuery(CQLSyntax.create).forcePad.append(CQLSyntax.index)
       .forcePad.append(CQLSyntax.ifNotExists)
+      .forcePad.append(s"${table}_${column}_idx")
       .forcePad.append(CQLSyntax.On)
       .forcePad.append(QueryBuilder.keyspace(keySpace, table))
       .wrapn(CQLQuery(CQLSyntax.Keys).wrapn(column))
@@ -221,6 +223,7 @@ private[builder] class CreateTableBuilder extends CompactionQueryBuilder with Co
   def mapEntries(table: String, keySpace: String, column: String): CQLQuery = {
     CQLQuery(CQLSyntax.create).forcePad.append(CQLSyntax.index)
       .forcePad.append(CQLSyntax.ifNotExists)
+      .forcePad.append(s"${table}_${column}_idx")
       .forcePad.append(CQLSyntax.On)
       .forcePad.append(QueryBuilder.keyspace(keySpace, table))
       .wrapn(CQLQuery(CQLSyntax.Entries).wrapn(column))

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/CreateQueryBuilderTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/CreateQueryBuilderTest.scala
@@ -199,13 +199,13 @@ class CreateQueryBuilderTest extends FreeSpec with Matchers with KeySpaceSuite {
       "specify a secondary index on a non-map column" in {
         val qb = QueryBuilder.Create.index("t", "k", "col").queryString
 
-        qb shouldEqual "CREATE INDEX IF NOT EXISTS ON k.t(col)"
+        qb shouldEqual "CREATE INDEX IF NOT EXISTS t_col_idx ON k.t(col)"
       }
 
       "specify a secondary index on a map column for the keys of a map column" in {
         val qb = QueryBuilder.Create.mapIndex("t", "k", "col").queryString
 
-        qb shouldEqual "CREATE INDEX IF NOT EXISTS ON k.t(KEYS(col))"
+        qb shouldEqual "CREATE INDEX IF NOT EXISTS t_col_idx ON k.t(KEYS(col))"
       }
     }
 


### PR DESCRIPTION
Related to Cassandra2 -> Cassandra3 transition.
What: Generate predictable name for a secondary index.
Why: In Cassandra 3 "CREATE INDEX" query without explicitly specifying an index name fails even with "IF NOT EXISTS" part. Seems that they've changed uniqueness property and "IF NOT EXISTS" will work only if index name is the same, rather than column used.