### PR TITLE
User-supplied executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This is a list of companies that have embraced phantom as part of their technolo
 - [Tecsisa](http://www.tecsisa.com/en/)
 - [Tuplejump](http://www.tuplejump.com/)
 - [FiloDB](http://www.github.com/tuplejump/FiloDB) - the fast analytics database built on Cassandra and Spark
+- [Chartboost](https://www.chartboost.com)
 
 
 License and copyright
@@ -122,6 +123,7 @@ Scala/Cassandra users in the world rely on phantom.
 * Stephen Samuel ([@sksamuel](https://github.com/sksamuel))
 * Evan Chan ([@evanfchan](https://github.com/evanfchan))
 * Jens Halm ([@jenshalm](https://github.com/jenshalm))
+* Donovan Levinson ([@levinson](https://github.com/levinson))
 
 <a id="copyright">Copyright</a>
 ===============================

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core.{Row, Session}
 import com.websudos.phantom.builder.clauses.DeleteClause
 import com.websudos.phantom.builder.query._
@@ -37,7 +39,7 @@ import com.websudos.phantom.connectors.KeySpace
 import com.websudos.phantom.exceptions.{InvalidClusteringKeyException, InvalidPrimaryKeyException}
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.reflect.runtime.{currentMirror => cm, universe => ru}
 
@@ -57,7 +59,12 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
   type JsonSetColumn[RR] = com.websudos.phantom.column.JsonSetColumn[T, R, RR]
   type JsonListColumn[RR] = com.websudos.phantom.column.JsonListColumn[T, R, RR]
 
-  private[phantom] def insertSchema()(implicit session: Session, keySpace: KeySpace): Unit = {
+  private[phantom] def insertSchema()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    executor: Executor,
+    ec: ExecutionContext
+  ): Unit = {
     Await.result(create.ifNotExists().future(), 10.seconds)
   }
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/Manager.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/Manager.scala
@@ -38,8 +38,6 @@ import scala.concurrent.ExecutionContext
 
 object Manager {
 
-  lazy val cores = Runtime.getRuntime.availableProcessors()
-
   lazy val taskExecutor = Executors.newCachedThreadPool()
 
   implicit lazy val scalaExecutor: ExecutionContext = ExecutionContext.fromExecutor(taskExecutor)

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/batch/BatchQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/batch/BatchQuery.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.batch
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core.{ QueryOptions => _, _ }
 import com.websudos.phantom.builder.query._
 import com.websudos.phantom.builder.syntax.CQLSyntax
@@ -36,7 +38,7 @@ import com.websudos.phantom.builder.{ConsistencyBound, QueryBuilder, Specified, 
 import com.websudos.phantom.connectors.KeySpace
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.{Future => ScalaFuture}
+import scala.concurrent.{ExecutionContext, Future => ScalaFuture}
 
 class BatchType(val batch: String)
 
@@ -55,7 +57,12 @@ sealed class BatchQuery[Status <: ConsistencyBound](
   override val options: QueryOptions
 ) extends ExecutableStatement {
 
-  override def future()(implicit session: Session, keySpace: KeySpace): ScalaFuture[ResultSet] = {
+  override def future()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    executor: Executor,
+    ec: ExecutionContext
+  ): ScalaFuture[ResultSet] = {
     scalaQueryStringExecuteToFuture(makeBatch())
   }
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.builder.query
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core._
 import com.google.common.util.concurrent.{FutureCallback, Futures}
 import com.websudos.phantom.Manager
@@ -40,14 +42,16 @@ private[phantom] trait CassandraOperations extends SessionAugmenterImplicits {
 
   protected[this] def scalaQueryStringExecuteToFuture(st: Statement)(
     implicit session: Session,
-    keyspace: KeySpace
+    keyspace: KeySpace,
+    executor: Executor
   ): ScalaFuture[ResultSet] = {
     scalaQueryStringToPromise(st).future
   }
 
   protected[this] def scalaQueryStringToPromise(st: Statement)(
     implicit session: Session,
-    keyspace: KeySpace
+    keyspace: KeySpace,
+    executor: Executor
   ): ScalaPromise[ResultSet] = {
     Manager.logger.debug(s"Executing query: ${st.toString}")
 
@@ -65,7 +69,7 @@ private[phantom] trait CassandraOperations extends SessionAugmenterImplicits {
         promise failure err
       }
     }
-    Futures.addCallback(future, callback, Manager.executor)
+    Futures.addCallback(future, callback, executor)
     promise
   }
 }

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CreateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CreateQuery.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.builder.query
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core._
 import com.websudos.phantom.builder._
 import com.websudos.phantom.builder.query.options.TablePropertyClause
@@ -189,10 +191,12 @@ class CreateQuery[
     })
   }
 
-  override def future()(implicit session: Session, keySpace: KeySpace): ScalaFuture[ResultSet] = {
-
-    implicit val ex: ExecutionContext = Manager.scalaExecutor
-
+  override def future()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    executor: Executor,
+    ec: ExecutionContext
+  ): ScalaFuture[ResultSet] = {
     if (table.secondaryKeys.isEmpty) {
       scalaQueryStringExecuteToFuture(new SimpleStatement(qb.terminate().queryString))
     } else {
@@ -208,7 +212,6 @@ class CreateQuery[
       }
     }
   }
-
 }
 
 object CreateQuery {

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.builder.query
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core.{ConsistencyLevel, Row, Session}
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder._
@@ -284,12 +286,21 @@ class SelectQuery[
 
   /**
    * Returns the first row from the select ignoring everything else
-   * @param session The Cassandra session in use.
-   * @param ctx The Execution Context.
-   * @return
+   * @param session The implicit session provided by a [[com.websudos.phantom.connectors.Connector]].
+   * @param keySpace The implicit keySpace definition provided by a [[com.websudos.phantom.connectors.Connector]].
+   * @param ev The implicit limit for the query.
+   * @param executor The implicit Java executor.
+   * @param ec The implicit Scala execution context.
+   * @return A Scala future guaranteed to contain a single result wrapped as an Option.
    */
   @implicitNotFound("You have already defined limit on this Query. You cannot specify multiple limits on the same builder.")
-  def one()(implicit session: Session, ctx: ExecutionContext, keySpace: KeySpace, ev: Limit =:= Unlimited): ScalaFuture[Option[Record]] = {
+  def one()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    ev: Limit =:= Unlimited,
+    executor: Executor,
+    ec: ExecutionContext
+  ): ScalaFuture[Option[Record]] = {
     val enforceLimit = if (count) LimitedPart.empty else limitedPart append QueryBuilder.limit(1)
 
     new SelectQuery(

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.builder.query.prepared
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core.{QueryOptions => _, _}
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder.query._
@@ -67,18 +69,27 @@ class ExecutablePreparedSelectQuery[
 
   override def fromRow(r: Row): R = fn(r)
 
-  override def future()(implicit session: Session, keySpace: KeySpace): ScalaFuture[ResultSet] = {
+  override def future()(implicit session: Session, keySpace: KeySpace, executor: Executor, ec: ExecutionContext): ScalaFuture[ResultSet] = {
     scalaQueryStringExecuteToFuture(st)
   }
 
 
   /**
-    * Returns the first row from the select ignoring everything else
-    *
-    * @param session The Cassandra session in use.
-    * @return A Scala future guaranteed to contain a single result wrapped as an Option.
-    */
-  override def one()(implicit session: Session, ec: ExecutionContext, keySpace: KeySpace, ev: =:=[Limit, Unlimited]): ScalaFuture[Option[R]] = {
+   * Returns the first row from the select ignoring everything else
+   * @param session The implicit session provided by a [[com.websudos.phantom.connectors.Connector]].
+   * @param keySpace The implicit keySpace definition provided by a [[com.websudos.phantom.connectors.Connector]].
+   * @param ev The implicit limit for the query.
+   * @param executor The implicit Java executor.
+   * @param ec The implicit Scala execution context.
+   * @return A Scala future guaranteed to contain a single result wrapped as an Option.
+   */
+  override def one()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    ev: =:=[Limit, Unlimited],
+    executor: Executor,
+    ec: ExecutionContext
+  ): ScalaFuture[Option[R]] = {
     singleFetch()
   }
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/db/DatabaseImpl.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/db/DatabaseImpl.scala
@@ -29,6 +29,8 @@
  */
 package com.websudos.phantom.db
 
+import java.util.concurrent.Executor
+
 import com.datastax.driver.core.{ResultSet, Session}
 import com.websudos.diesel.engine.reflection.EarlyInit
 import com.websudos.phantom.CassandraTable
@@ -110,8 +112,12 @@ abstract class DatabaseImpl(val connector: KeySpaceDef) extends EarlyInit[Cassan
 
 sealed class ExecutableCreateStatementsList(val tables: Set[CassandraTable[_, _]]) {
 
-  def future()(implicit session: Session, keySpace: KeySpace, ec: ExecutionContext): Future[Seq[ResultSet]] = {
+  def future()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    executor: Executor,
+    ec: ExecutionContext
+  ): Future[Seq[ResultSet]] = {
     Future.sequence(tables.toSeq.map(_.create.ifNotExists().future()))
   }
-
 }

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
@@ -31,6 +31,7 @@ package com.websudos.phantom
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
+import java.util.concurrent.Executor
 import java.util.{Date, Random}
 
 import com.datastax.driver.core.utils.UUIDs
@@ -44,6 +45,7 @@ import com.websudos.phantom.builder.query.{CQLQuery, CreateImplicits, DeleteImpl
 import com.websudos.phantom.builder.syntax.CQLSyntax
 import shapeless.{::, HNil}
 
+import scala.concurrent.ExecutionContext
 import scala.util.Try
 import scala.util.control.NoStackTrace
 
@@ -179,7 +181,9 @@ package object dsl extends ImplicitMechanism with CreateImplicits
     new TokenConstructor(Seq(Primitive[RR].asCql(value)))
   }
 
-  implicit lazy val context = Manager.scalaExecutor
+  implicit lazy val context: ExecutionContext = Manager.scalaExecutor
+
+  implicit lazy val executor: Executor = Manager.taskExecutor
 
   implicit class PartitionTokenHelper[T](val p: Column[_, _, T] with PartitionKey[T]) extends AnyVal {
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
@@ -183,7 +183,7 @@ package object dsl extends ImplicitMechanism with CreateImplicits
 
   implicit lazy val context: ExecutionContext = Manager.scalaExecutor
 
-  implicit lazy val executor: Executor = Manager.taskExecutor
+  implicit lazy val executor: Executor = Manager.executor
 
   implicit class PartitionTokenHelper[T](val p: Column[_, _, T] with PartitionKey[T]) extends AnyVal {
 

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/compilation/ModifyOperatorRestrictions.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/compilation/ModifyOperatorRestrictions.scala
@@ -42,7 +42,6 @@ class ModifyOperatorRestrictions extends FlatSpec with Matchers with ParallelTes
   val TimeSeriesTable = TestDatabase.timeSeriesTable
   val CounterTableTest = TestDatabase.counterTableTest
   val TwoKeys = TestDatabase.twoKeysTable
-  val c = context
   val update = gen[String]
 
   it should "not allow using the setTo operator on a Counter column" in {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/compilation/WhereClauseRestrictionsTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/compilation/WhereClauseRestrictionsTest.scala
@@ -39,7 +39,6 @@ class WhereClauseRestrictionsTest extends FlatSpec with Matchers with KeySpaceSu
 
   val s = gen[String]
   val Primitives = TestDatabase.primitives
-  val c = context
 
   it should "allow using a Select.Where clause" in {
     "Primitives.select.where(_.pkey eqs gen[String])" should compile


### PR DESCRIPTION
# Overview
I didn't like that phantom used a caching thread pool Java executor under the hood, and that there was no way to supply your own executor. It also seems that the implicit Scala execution context was not being used everywhere the code dealt with Scala futures.

# Details
* Executor and execution contexts are now passed around implicitly everywhere.
* User can now use custom executor and execution context or import the default ones from dsl package.
* Updated scaladoc method comments for new executors.
* Cleaned up ordering of executors in implicit arguments.
* Added myself to contributors and Chartboost to companies.