### PR TITLE
Substitute Recipes with ConcreteRecipes in Recipes class signature.

### DIFF
--- a/phantom-example/src/main/scala/com/websudos/phantom/example/basics/SimpleRecipes.scala
+++ b/phantom-example/src/main/scala/com/websudos/phantom/example/basics/SimpleRecipes.scala
@@ -65,7 +65,7 @@ case class Recipe(
 // You can seal the class and only allow importing the companion object.
 // The companion object is where you would implement your custom methods.
 // Keep reading for examples.
-sealed class Recipes extends CassandraTable[Recipes, Recipe] {
+sealed class Recipes extends CassandraTable[ConcreteRecipes, Recipe] {
   object id extends  UUIDColumn(this) with PartitionKey[UUID] {
     // You can override the name of your key to whatever you like.
     // The default will be the name used for the object, in this case "id".


### PR DESCRIPTION
As the title implies, I've just substituted Recipes with ConcreteRecipes in Recipes class signature.