### PR TITLE
Fixed "order by" select statement builder and related tests.

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/serializers/SelectQueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/serializers/SelectQueryBuilder.scala
@@ -67,7 +67,8 @@ sealed class OrderingModifier {
   def orderBy(clauses: CQLQuery*): CQLQuery = clauses match {
     case head :: tail if tail.isEmpty =>
       CQLQuery(CQLSyntax.Selection.OrderBy).forcePad.append(head.queryString)
-    case _ => CQLQuery(CQLSyntax.Selection.OrderBy).forcePad.wrap(clauses.map(_.queryString))
+    case _ =>
+      CQLQuery(CQLSyntax.Selection.OrderBy).forcePad.append(clauses.map(_.queryString))
   }
 
   def orderBy(qb: CQLQuery, clause: CQLQuery): CQLQuery = {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/SelectQueryBuilderTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/SelectQueryBuilderTest.scala
@@ -94,7 +94,7 @@ class SelectQueryBuilderTest extends QueryBuilderTest {
 
         val qb = QueryBuilder.Select.Ordering.orderBy(orderings: _*).queryString
 
-        qb shouldEqual "ORDER BY (test ASC, test_2 ASC, test_3 DESC)"
+        qb shouldEqual "ORDER BY test ASC, test_2 ASC, test_3 DESC"
       }
     }
 

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/SelectQuerySerialisationTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/SelectQuerySerialisationTest.scala
@@ -109,7 +109,7 @@ class SelectQuerySerialisationTest extends QueryBuilderTest {
 
         val qb = BasicTable.select.where(_.id eqs id).orderBy(_.id2.desc, _.id3.asc).queryString
 
-        qb shouldEqual s"SELECT * FROM phantom.basicTable WHERE id = ${id.toString} ORDER BY (id2 DESC, id3 ASC);"
+        qb shouldEqual s"SELECT * FROM phantom.basicTable WHERE id = ${id.toString} ORDER BY id2 DESC, id3 ASC;"
       }
 
       "a maxTimeuuid comparison clause" in {


### PR DESCRIPTION
"Order by" will no longer wrap it's list of values with parentheses.

According to Apache CQL doc, the "ordering clause" does not require surrounding parentheses: http://cassandra.apache.org/doc/latest/cql/dml.html#select

```
select_statement ::=  SELECT [ JSON | DISTINCT ] ( select_clause | '*' )
                      FROM table_name
                      [ WHERE where_clause ]
                      [ ORDER BY ordering_clause ]
                      [ PER PARTITION LIMIT (integer | bind_marker) ]
                      [ LIMIT (integer | bind_marker) ]
                      [ ALLOW FILTERING ]
...
ordering_clause  ::=  column_name [ ASC | DESC ] ( ',' column_name [ ASC | DESC ] )*
```

Tested w/ surrounding parens in Cassandra 2.1.12, 3.0.0, and 3.7, all of which failed.