### PR TITLE
Feature/timestamp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,8 +146,8 @@ val sharedSettings: Seq[Def.Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     "org.slf4j" % "log4j-over-slf4j" % Versions.slf4j
   ) ++ scalaMacroDependencies(scalaVersion.value),
   fork in Test := true,
-  javaOptions in ThisBuild ++= Seq(
-    "-Xmx2G",
+  javaOptions ++= Seq(
+    "-Xmx1G",
     "-Djava.net.preferIPv4Stack=true",
     "-Dio.netty.resourceLeakDetection"
   ),

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/QueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/QueryBuilder.scala
@@ -81,10 +81,6 @@ abstract class QueryBuilder(val config: QueryBuilderConfig = QueryBuilderConfig.
     CQLQuery(CQLSyntax.CreateOptions.ttl).forcePad.append(seconds)
   }
 
-  def timestamp(qb: CQLQuery, seconds: String): CQLQuery = {
-    qb.pad.append(CQLSyntax.timestamp).forcePad.append(seconds)
-  }
-
   def timestamp(seconds: String): CQLQuery = {
     CQLQuery(CQLSyntax.timestamp).forcePad.append(seconds)
   }

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/UpdateQuery.scala
@@ -462,6 +462,18 @@ sealed class ConditionalQuery[
     }
   }
 
+  final def timestamp(value: Long): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
+    new ConditionalQuery(
+      table = table,
+      init = init,
+      usingPart = usingPart append QueryBuilder.timestamp(value.toString),
+      wherePart = wherePart,
+      setPart = setPart,
+      casPart = casPart,
+      options = options
+    )
+  }
+
   def ttl(seconds: Long): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
     new ConditionalQuery(
       table,
@@ -474,7 +486,7 @@ sealed class ConditionalQuery[
     )
   }
 
-  final def ttl(duration: scala.concurrent.duration.FiniteDuration): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
+  final def ttl(duration: ScalaDuration): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
     ttl(duration.toSeconds)
   }
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/UpdateQuery.scala
@@ -291,7 +291,7 @@ sealed class AssignmentsQuery[
     new AssignmentsQuery(
       table = table,
       init = init,
-      usingPart = usingPart append QueryBuilder.timestamp(init, value.toString),
+      usingPart = usingPart append QueryBuilder.timestamp(value.toString),
       wherePart = wherePart,
       setPart = setPart,
       casPart = casPart,

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/PhantomSuite.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/PhantomSuite.scala
@@ -32,7 +32,7 @@ package com.websudos.phantom
 import java.util.concurrent.TimeUnit
 
 import com.websudos.phantom.connectors.{RootConnector, VersionNumber}
-import com.websudos.phantom.tables.TestDatabase
+import com.websudos.phantom.tables.{Primitive, TestDatabase}
 import com.outworkers.util.lift.{DateTimeSerializer, UUIDSerializer}
 import org.scalatest._
 import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
@@ -60,6 +60,12 @@ trait PhantomBaseSuite extends Suite with Matchers
     timeout = defaultTimeoutSpan,
     interval = Span(defaultScalaInterval, Millis)
   )
+
+  implicit class CqlConverter[T](val obj: T) {
+    def asCql()(implicit primitive: com.websudos.phantom.builder.primitives.Primitive[T]): String = {
+      primitive.asCql(obj)
+    }
+  }
 }
 
 trait PhantomSuite extends FlatSpec with PhantomBaseSuite with TestDatabase.connector.Connector {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/crud/SelectJsonTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/crud/SelectJsonTest.scala
@@ -62,7 +62,6 @@ class SelectJsonTest extends PhantomSuite {
     } else {
       chain.failing[SyntaxError]
     }
-
   }
 
   "A JSON selection clause" should "8 columns as JSON" in {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQueryBuilderTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQueryBuilderTest.scala
@@ -31,6 +31,7 @@ package com.websudos.phantom.builder.serializers
 
 import com.websudos.phantom.builder.QueryBuilder
 import com.websudos.phantom.builder.query.QueryBuilderTest
+import com.outworkers.util.testing._
 
 class UpdateQueryBuilderTest extends QueryBuilderTest {
 
@@ -56,7 +57,11 @@ class UpdateQueryBuilderTest extends QueryBuilderTest {
       }
     }
 
-    "should allow specifying WHERE options" - {
+    "should allow specifying USING clause options" - {
+      "should allow specifying a timestamp clause" in {
+        val str = gen[Long]
+        QueryBuilder.timestamp(str.toString).queryString shouldEqual s"TIMESTAMP $str"
+      }
     }
 
     "should allow specifying CAS options" - {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/tables/PrimitivesJoda.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/tables/PrimitivesJoda.scala
@@ -29,9 +29,12 @@
  */
 package com.websudos.phantom.tables
 
+import com.datastax.driver.core.PagingState
 import com.websudos.phantom.builder.query.InsertQuery
 import com.websudos.phantom.dsl._
 import org.joda.time.DateTime
+
+import scala.concurrent.Future
 
 case class JodaRow(
   pkey: String,
@@ -59,6 +62,10 @@ abstract class ConcretePrimitivesJoda extends PrimitivesJoda with RootConnector 
     insert.value(_.pkey, primitive.pkey)
       .value(_.intColumn, primitive.int)
       .value(_.timestamp, primitive.bi)
+  }
+
+  def getPage(limit: Int, paging: Option[PagingState]): Future[ListResult[JodaRow]] = {
+    select.limit(limit).fetchRecord(paging)
   }
 
   override val tableName = "PrimitivesJoda"


### PR DESCRIPTION
- Adding support for `timestamp` clauses on conditional update queries that use `onlyIf`.
- Fixing serialisation bug in the `AssignmentsQuery` method that chains `timestamp`.
- Removed deprecated method from former API that didn't use multi-part queries.
- Added more tests to cover serialisation of timestamps. 