### PR TITLE
Feature/from row macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ part of long term re-branding efforts, we have finally felt it's time to make su
 - There is a new and now completely optional Bintray resolver, `Resolver.bintrayRepo("outworkers", "oss-releases")`,
  that gives you free access to the latest cuts of our open source releases before they hit Maven Central. We assume
  no liability for your usage of latest cuts, but we welcome feedback and we do our best to have elaborate CI processes in place.
+- Manually defining a `fromRow` inside a `CassandraTable` is no longer required if your column types match your case class types.
 - `EnumColumn` is now relying entirely on `Primitive.macroImpl`, which means you will not need to pass in the enumeration
 as an argument to `EnumColumn` anymore. This means `object enum extends EnumColumn(this, enum: MyEnum)` is now simply
 `object enum extends EnumColumn[MyEnum#Value]`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ projects which have in their own right been completely open sourced under Apache
 - A new, macro based mechanism now performs the same auto-discovery task that reflection used to, thanks to `macro-compat`.
 - Index modifiers no longer require a type parameter, `PartitionKey`, `PrimaryKey`, `ClusteringOrder` and `Index` don't require
 the column type passed anymore.
-- `KeySpaceDef` has been renamed to the more appropiate `CassandraConnector`.
+- `KeySpaceDef` has been renamed to the more appropiate `
+CassandraConnector`.
 - `CassandraConnector` now natively supports specifying a keyspace creation query.
 - `TimeWindowCompactionStrategy` is now natively supported in the CREATE/ALTER dsl.
 - Collections can now be used as part of a primary or partition key.

--- a/phantom-connectors/src/main/scala/com/outworkers/phantom/connectors/Keyspace.scala
+++ b/phantom-connectors/src/main/scala/com/outworkers/phantom/connectors/Keyspace.scala
@@ -59,11 +59,15 @@ class CassandraConnection(
   autoinit: Boolean,
   keyspaceFn: Option[(Session, KeySpace) => String] = None,
   errorHander: Throwable => Throwable = identity
-) {
+) { outer =>
 
-  val provider = new DefaultSessionProvider(KeySpace(name), clusterBuilder, autoinit, keyspaceFn, errorHander)
-
-  val self = this
+  lazy val provider = new DefaultSessionProvider(
+    KeySpace(name),
+    clusterBuilder,
+    autoinit,
+    keyspaceFn,
+    errorHander
+  )
 
   /**
    * The Session associated with this keySpace.
@@ -107,15 +111,15 @@ class CassandraConnection(
    */
   trait Connector extends com.outworkers.phantom.connectors.Connector with SessionAugmenterImplicits {
 
-    lazy val provider = self.provider
+    lazy val provider = outer.provider
 
-    lazy val keySpace = self.name
+    lazy val keySpace = outer.name
 
-    implicit val space: KeySpace = KeySpace(self.name)
+    implicit val space: KeySpace = KeySpace(outer.name)
 
-    def cassandraVersion: Option[VersionNumber] = self.cassandraVersion
+    def cassandraVersion: Option[VersionNumber] = outer.cassandraVersion
 
-    def cassandraVersions: Set[VersionNumber] = self.cassandraVersions
+    def cassandraVersions: Set[VersionNumber] = outer.cassandraVersions
   }
 
 }

--- a/phantom-connectors/src/main/scala/com/outworkers/phantom/connectors/package.scala
+++ b/phantom-connectors/src/main/scala/com/outworkers/phantom/connectors/package.scala
@@ -22,4 +22,7 @@ package object connectors {
   type ClusterBuilder = (Cluster.Builder => Cluster.Builder)
 
   type VersionNumber = com.datastax.driver.core.VersionNumber
+
+  @deprecated("Renamed to the more descriptive CassandraConnection", "2.0.0")
+  type KeySpaceDef = com.outworkers.phantom.connectors.CassandraConnection
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -34,9 +34,9 @@ import scala.concurrent.{Await, ExecutionContextExecutor}
  */
 abstract class CassandraTable[T <: CassandraTable[T, R], R](
   implicit helper: TableHelper[T, R]
-) extends SelectTable[T, R] { self: CassandraTable[T, R] =>
+) extends SelectTable[T, R] { self =>
 
-  def columns: Set[AbstractColumn[_]] = helper.fields(this)
+  def columns: Set[AbstractColumn[_]] = helper.fields(self)
 
   def secondaryKeys: Set[AbstractColumn[_]] = columns.filter(_.isSecondaryKey)
 
@@ -51,7 +51,7 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
   @deprecated("Method replaced with macro implementation", "2.0.0")
   def defineTableKey(): String = tableKey
 
-  def instance: T = this.asInstanceOf[T]
+  def instance: T = self.asInstanceOf[T]
 
   lazy val logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -79,7 +79,7 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
 
   def tableName: String = helper.tableName
 
-  def fromRow(r: Row): R
+  def fromRow(r: Row): R = helper.fromRow(instance, r)
 
   /**
    * The new create mechanism introduced in Phantom 1.6.0.

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -46,6 +46,11 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
 
   def clusteringColumns: Set[AbstractColumn[_]] = columns.filter(_.isClusteringKey)
 
+  def tableKey: String = helper.tableKey(instance)
+
+  @deprecated("Method replaced with macro implementation", "2.0.0")
+  def defineTableKey(): String = tableKey
+
   def instance: T = this.asInstanceOf[T]
 
   lazy val logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -38,23 +38,17 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
 
   def columns: Set[AbstractColumn[_]] = helper.fields(this)
 
-  def secondaryKeys: Set[AbstractColumn[_]] = {
-    columns.filter(_.isSecondaryKey)
-  }
+  def secondaryKeys: Set[AbstractColumn[_]] = columns.filter(_.isSecondaryKey)
 
-  def primaryKeys: Set[AbstractColumn[_]] = {
-    columns.filter(_.isPrimary).filterNot(_.isPartitionKey)
-  }
+  def primaryKeys: Set[AbstractColumn[_]] = columns.filter(_.isPrimary).filterNot(_.isPartitionKey)
 
-  def partitionKeys: Set[AbstractColumn[_]] = {
-    columns.filter(_.isPartitionKey)
-  }
+  def partitionKeys: Set[AbstractColumn[_]] = columns.filter(_.isPartitionKey)
 
-  def clusteringColumns: Set[AbstractColumn[_]] = {
-    columns.filter(_.isClusteringKey)
-  }
+  def clusteringColumns: Set[AbstractColumn[_]] = columns.filter(_.isClusteringKey)
 
-  protected[this] def instance: T = this.asInstanceOf[T]
+  def instance: T = this.asInstanceOf[T]
+
+  lazy val logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))
 
   type ListColumn[RR] = com.outworkers.phantom.column.ListColumn[T, R, RR]
   type SetColumn[RR] =  com.outworkers.phantom.column.SetColumn[T, R, RR]
@@ -74,8 +68,6 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
   ): Unit = {
     Await.result(autocreate(keySpace).future(), 10.seconds)
   }
-
-  lazy val logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))
 
   def tableName: String = helper.tableName
 
@@ -101,109 +93,10 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
   final def delete(
     conditions: (T => DeleteClause.Condition)*
   )(implicit keySpace: KeySpace): DeleteQuery.Default[T, R] = {
-    DeleteQuery[T, R](
-      instance,
-      conditions.map(_(instance).qb): _*
-    )
+    DeleteQuery[T, R](instance, conditions.map(_(instance).qb): _*)
   }
 
   final def truncate()(
     implicit keySpace: KeySpace
   ): TruncateQuery.Default[T, R] = TruncateQuery[T, R](instance)
-
-  def clustered: Boolean = clusteringColumns.nonEmpty
-
-  /**
-    * This method will filter the columns from a Clustering Order definition.
-    * It is used to define TimeSeries tables, using the ClusteringOrder trait
-    * combined with a directional trait, either Ascending or Descending.
-    *
-    * This method will simply add to the trailing of a query.
-    * @return The clustering key, defined as a string or the empty string.
-    */
-  private[phantom] def clusteringKey: String = {
-    if (clusteringColumns.nonEmpty) {
-      val key = clusteringColumns.map(col => {
-        val direction = if (col.isAscending) {
-          "ASC"
-        } else {
-          "DESC"
-        }
-        s"${col.name} $direction"
-      })
-      s"WITH CLUSTERING ORDER BY (${key.mkString(", ")})"
-    } else {
-      ""
-    }
-  }
-
-  /**
-    * This method will define the PRIMARY_KEY of the table.
-    * <ul>
-    *   <li>
-    *    For more than one partition key, it will define a Composite Key.
-    *    Example: PRIMARY_KEY((partition_key_1, partition_key2), primary_key_1, etc..)
-    *   </li>
-    *   <li>
-    *     For a single partition key, it will define a Compound Key.
-    *     Example: PRIMARY_KEY(partition_key_1, primary_key_1, primary_key_2)
-    *   </li>
-    *   <li>
-    *     For no partition key, it will throw an exception.
-    *   </li>
-    * </ul>
-    * @return A string value representing the primary key of the table.
-    */
-  @throws(classOf[InvalidPrimaryKeyException])
-  private[phantom] def defineTableKey(): String = {
-
-    preconditions()
-
-    // Get the list of primary keys that are not partition keys.
-    val primaries = primaryKeys
-    val primaryString = primaryKeys.map(_.name).mkString(", ")
-
-    // Get the list of partition keys that are not primary keys
-    // This is done to avoid including the same columns twice.
-    val partitions = partitionKeys.toList
-    val partitionString = s"(${partitions.map(_.name).mkString(", ")})"
-
-    val operand = partitions.lengthCompare(1)
-    val key = if (operand < 0) {
-      throw InvalidPrimaryKeyException(tableName)
-    } else if (operand == 0) {
-
-      val partitionKey = partitions.headOption.map(_.name).orNull
-
-      if (primaries.isEmpty) {
-        partitionKey
-      } else {
-        s"$partitionKey, $primaryString"
-      }
-    } else {
-      if (primaries.isEmpty) {
-        partitionString
-      } else {
-        s"$partitionString, $primaryString"
-      }
-    }
-    s"PRIMARY KEY ($key)"
-  }
-
-  /**
-    * This method will check for common Cassandra anti-patterns during the intialisation of a schema.
-    * If the Schema definition violates valid CQL standard, this function will throw an error.
-    *
-    * A perfect example is using a mixture of Primary keys and Clustering keys in the same schema.
-    * While a Clustering key is also a primary key, when defining a clustering key all other keys must become clustering keys and specify their order.
-    *
-    * We could auto-generate this order but we wouldn't be making false assumptions about the desired ordering.
-    */
-  private[this] def preconditions(): Unit = {
-    if (clustered && primaryKeys.diff(clusteringColumns).nonEmpty) {
-      logger.error("When using CLUSTERING ORDER all PrimaryKey definitions" +
-        " must become a ClusteringKey definition and specify order.")
-      throw InvalidClusteringKeyException(tableName)
-    }
-  }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -83,7 +83,13 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
    * This uses the phantom proprietary QueryBuilder instead of the already available one in the underlying Java Driver.
    * @return A root create block, with full support for all CQL Create query options.
    */
-  final def create: RootCreateQuery[T, R] = new RootCreateQuery(instance)
+  final def create: RootCreateQuery[T, R] = new RootCreateQuery(
+    tableName,
+    tableKey,
+    columns.map(_.qb),
+    clusteringColumns,
+    secondaryKeys
+  )
 
   def autocreate(keySpace: KeySpace): CreateQuery.Default[T, R] = create.ifNotExists()(keySpace)
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CreateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CreateQuery.scala
@@ -35,7 +35,7 @@ class RootCreateQuery[
     QueryBuilder.Create.defaultCreateQuery(
       keySpace.name,
       table.tableName,
-      table.defineTableKey(),
+      table.tableKey,
       table.columns.map(_.qb).toSeq
     )
   }
@@ -48,7 +48,7 @@ class RootCreateQuery[
     QueryBuilder.Create.createIfNotExists(
       keySpace.name,
       table.tableName,
-      table.defineTableKey(),
+      table.tableKey,
       table.columns.map(_.qb).toSeq
     )
   }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
@@ -116,7 +116,8 @@ private[builder] class CreateTableBuilder {
       // in the same table.
       val finalKeys = primaries ::: clusteringKeys
       root.append(CQLSyntax.comma)
-          .append(CQLQuery.empty.wrap(finalKeys))
+        .forcePad
+          .append(finalKeys)
           .append(CQLSyntax.`)`)
     } else {
       root.append(CQLSyntax.`)`)

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
@@ -65,7 +65,7 @@ private[builder] class CreateTableBuilder {
   def partitionKey(keys: List[String]): CQLQuery = {
     keys match {
       case head :: Nil => CQLQuery(head)
-      case head :: tail => CQLQuery.empty.wrap(keys)
+      case head :: tail => CQLQuery.empty.wrapn(keys)
       case _ => CQLQuery.empty
     }
   }
@@ -111,10 +111,10 @@ private[builder] class CreateTableBuilder {
       .append(CQLSyntax.`(`)
       .append(partitionKey(partitions))
 
-    val stage2 = if (primaries.nonEmpty || clusteringKeys.nonEmpty) {
+    val stage2 = if (primaries.nonEmpty) {
       // This only works because the macro prevents the user from defining both primaries and clustering keys
       // in the same table.
-      val finalKeys = primaries ::: clusteringKeys
+      val finalKeys = primaries.toSet
       root.append(CQLSyntax.comma)
         .forcePad
           .append(finalKeys)
@@ -247,7 +247,7 @@ private[builder] class CreateTableBuilder {
   }
 
   def clusteringOrder(orderings: List[(String, String)]): CQLQuery = {
-    val list = orderings.foldRight(List.empty[String]){ case ((key, value), l) =>
+    val list = orderings.foldRight(List.empty[String]) { case ((key, value), l) =>
       (key + " " + value) :: l
     }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilder.scala
@@ -62,6 +62,59 @@ private[builder] class CreateTableBuilder {
 
   object Caching extends CachingQueryBuilder
 
+  def partitionKey(keys: List[String]): CQLQuery = {
+    keys match {
+      case head :: tail => CQLQuery.empty.wrap(keys)
+      case head :: Nil => CQLQuery(head)
+      case _ => CQLQuery.empty
+    }
+  }
+
+  /**
+    * This method will filter the columns from a Clustering Order definition.
+    * It is used to define TimeSeries tables, using the ClusteringOrder trait
+    * combined with a directional trait, either Ascending or Descending.
+    *
+    * This method will simply add to the trailing of a query.
+    * @return The clustering key, defined as a string or the empty string.
+    */
+  def clusteringKey(keys: List[String]): CQLQuery = {
+    keys match {
+      case head :: tail => CQLQuery.empty.pad.append("WITH CLUSTERING ORDER BY").wrap(keys)
+      case _ => CQLQuery.empty
+    }
+  }
+
+  /**
+    * This method will define the PRIMARY_KEY of the table.
+    * <ul>
+    *   <li>
+    *    For more than one partition key, it will define a Composite Key.
+    *    Example: PRIMARY_KEY((partition_key_1, partition_key2), primary_key_1, etc..)
+    *   </li>
+    *   <li>
+    *     For a single partition key, it will define a Compound Key.
+    *     Example: PRIMARY_KEY(partition_key_1, primary_key_1, primary_key_2)
+    *   </li>
+    *   <li>
+    *     For no partition key, it will throw an exception.
+    *   </li>
+    * </ul>
+    * @return A string value representing the primary key of the table.
+    */
+  def primaryKey(
+    partitions: List[String],
+    primaries: List[String],
+    clusteringKeys: List[String]
+  ): CQLQuery = {
+    CQLQuery("PRIMARY KEY").forcePad
+      .append(CQLSyntax.`(`)
+      .append(partitionKey(partitions))
+      .append(CQLSyntax.comma)
+      .append(CQLSyntax.`)`)
+      .append(clusteringKey(clusteringKeys))
+  }
+
   def read_repair_chance(st: String): CQLQuery = {
     Utils.tableOption(CQLSyntax.CreateOptions.read_repair_chance, st)
   }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
@@ -61,7 +61,7 @@ abstract class Database[
    * @return An executable statement list that can be used with Scala or Twitter futures to simultaneously
    *         execute an entire sequence of queries.
    */
-  def autocreate(): ExecutableCreateStatementsList = helper.createQueries(this.asInstanceOf[DB])
+  private[phantom] def autocreate(): ExecutableCreateStatementsList = helper.createQueries(this.asInstanceOf[DB])
 
   /**
     * A blocking method that will create all the tables. This is designed to prevent the
@@ -97,7 +97,7 @@ abstract class Database[
    * @return An executable statement list that can be used with Scala or Twitter futures to simultaneously
    *         execute an entire sequence of queries.
    */
-  def autodrop(): ExecutableStatementList = {
+  private[phantom] def autodrop(): ExecutableStatementList = {
     new ExecutableStatementList(tables.toSeq.map {
       table => table.alter().drop().qb
     })
@@ -137,10 +137,8 @@ abstract class Database[
    * @return An executable statement list that can be used with Scala or Twitter futures to simultaneously
    *         execute an entire sequence of queries.
    */
-  def autotruncate(): ExecutableStatementList = {
-    new ExecutableStatementList(tables.toSeq.map {
-      table => table.truncate().qb
-    })
+  private[phantom] def autotruncate(): ExecutableStatementList = {
+    new ExecutableStatementList(tables.toSeq.map(_.truncate().qb))
   }
 
   /**

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
@@ -52,10 +52,12 @@ class MacroUtils(val c: blackbox.Context) {
   ): Set[Symbol] = {
     val tpe = weakTypeOf[T].typeSymbol.typeSignature
 
-    (for {
-      baseClass <- tpe.baseClasses.reverse.flatMap(x => exclusions(x))
-      symbol <- baseClass.typeSignature.members.sorted
-      if symbol.typeSignature <:< typeOf[Filter]
-    } yield symbol)(collection.breakOut)
+    (
+      for {
+        baseClass <- tpe.baseClasses.reverse.flatMap(exclusions(_))
+        symbol <- baseClass.typeSignature.members.sorted
+        if symbol.typeSignature <:< typeOf[Filter]
+      } yield symbol
+    )(collection.breakOut)
   }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
@@ -47,6 +47,21 @@ class MacroUtils(val c: blackbox.Context) {
     }
   }
 
+  def filterMembers[Filter : TypeTag](
+    tag: Type,
+    exclusions: Symbol => Option[Symbol]
+  ): Set[Symbol] = {
+    val tpe = tag.typeSymbol.typeSignature
+
+    (
+      for {
+        baseClass <- tpe.baseClasses.reverse.flatMap(exclusions(_))
+        symbol <- baseClass.typeSignature.members.sorted
+        if symbol.typeSignature <:< typeOf[Filter]
+      } yield symbol
+      )(collection.breakOut)
+  }
+
   def filterMembers[T : WeakTypeTag, Filter : TypeTag](
     exclusions: Symbol => Option[Symbol] = { s: Symbol => Some(s) }
   ): Set[Symbol] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
@@ -50,7 +50,7 @@ class MacroUtils(val c: blackbox.Context) {
   def filterMembers[Filter : TypeTag](
     tag: Type,
     exclusions: Symbol => Option[Symbol]
-  ): Set[Symbol] = {
+  ): Seq[Symbol] = {
     val tpe = tag.typeSymbol.typeSignature
 
     (
@@ -59,12 +59,12 @@ class MacroUtils(val c: blackbox.Context) {
         symbol <- baseClass.typeSignature.members.sorted
         if symbol.typeSignature <:< typeOf[Filter]
       } yield symbol
-      )(collection.breakOut)
+      )(collection.breakOut) distinct
   }
 
   def filterMembers[T : WeakTypeTag, Filter : TypeTag](
     exclusions: Symbol => Option[Symbol] = { s: Symbol => Some(s) }
-  ): Set[Symbol] = {
+  ): Seq[Symbol] = {
     val tpe = weakTypeOf[T].typeSymbol.typeSignature
 
     (
@@ -73,6 +73,6 @@ class MacroUtils(val c: blackbox.Context) {
         symbol <- baseClass.typeSignature.members.sorted
         if symbol.typeSignature <:< typeOf[Filter]
       } yield symbol
-    )(collection.breakOut)
+    )(collection.breakOut) distinct
   }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -258,6 +258,7 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
           }
        }
      """
+    Console.println(tree)
     tree
   }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -211,7 +211,6 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
   def macroImpl[T : WeakTypeTag, R : WeakTypeTag]: Tree = {
     val tpe = weakTypeOf[T]
 
-    val sourceName = tpe.typeSymbol.name.decodedName
     val rTpe = weakTypeOf[R]
 
     val colTpe = tq"com.outworkers.phantom.column.AbstractColumn[_]"
@@ -221,12 +220,9 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
     val columns = filterMembers[T, AbstractColumn[_]](exclusions)
 
-    Console.println("Column definitions")
-    Console.println(columns.map(_.name.decodedName.toString).mkString("\n"))
-
     val accessors = columns.map(_.asTerm.name).map(tm => q"table.instance.${tm.toTermName}")
 
-    val tree = q"""
+    q"""
        new com.outworkers.phantom.macros.TableHelper[$tpe, $rTpe] {
           def tableName: $strTpe = ${finalName.toString.capitalize}
 
@@ -239,8 +235,6 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
           }
        }
      """
-    Console.println(showCode(tree))
-    tree
   }
 
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -20,6 +20,7 @@ import com.outworkers.phantom.SelectTable
 import com.outworkers.phantom.column.{AbstractColumn, PrimitiveColumn}
 import com.outworkers.phantom.dsl.CassandraTable
 
+import scala.collection.immutable.ListSet
 import scala.reflect.macros.blackbox
 
 trait TableHelper[T <: CassandraTable[T, R], R] {
@@ -74,48 +75,100 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
     })
   }
 
+  /**
+    * Materializes an extractor method for a table, the so called "fromRow" method.
+    *
+    * This will only work if the types of the [[R]] record type match the types
+    * inferred by the return types of the columns inside the table.
+    *
+    * If the implementation could not be inferred, the output of this method will be the unimplemented
+    * method exception and the user will have to manually override the fromRow definition and create one
+    * themselves.
+    *
+    * {{{
+    *   def fromRow(row: Row): R = ???
+    * }}}
+    *
+    * Not only that but they also have to be in the same order. For example:
+    * {{{
+    *   case class MyRecord(
+    *     id: UUID,
+    *     email: String,
+    *     date: DateTime
+    *   )
+    *
+    *   class MyTable extends CassandraTable[MyTable, MyRecord] {
+    *     object id extends UUIDColumn(this) with PartitionKey
+    *     object email extends StringColumn(this)
+    *     object date extends DateTimeColumn(this)
+    *   }
+    * }}}
+    *
+    * @tparam T The type of the Cassandra table to infer the extractor for.
+    * @tparam R The record type to infer the extractor for.
+    * @return An interpolated tree that will contain the automatically generated implementation
+    *         of the fromRow method in a Cassandra Table.
+    *         Alternatively, this will return an unimplemented ??? method, provided a correct
+    *         definition could not be inferred.
+    */
   def materializeExtractor[T : WeakTypeTag, R : WeakTypeTag]: Tree = {
     val tableTpe = weakTypeOf[T]
     val recordTpe = weakTypeOf[R]
+
+    val rowTerm = TermName("row")
+
     val sourceMembers = filterMembers[T, AbstractColumn[_]](exclusions)
+    val columnNames = sourceMembers.map(
+      tpe => {
+        q"${tpe.typeSignatureIn(tableTpe).typeSymbol.name.toTermName}.apply($rowTerm)"
+      }
+    )
 
-    Console.println(sourceMembers)
+    /**
+      * First we create a set of ordered types corresponding to the type signatures
+      * found in the case class arguments.
+      */
+    val recordMembers = fields(recordTpe) map (_._2)
 
-
-    val columns = sourceMembers.map(_.asModule.info)
-    val records = fields(recordTpe) map (_._2) toSet
-
+    /**
+      * Then we do the same for the columns, we filter for the members of [[T]] that
+      * directly subclass [[AbstractColumn[_]]. For every one of those methods, we
+      * are going to look at what type argumnt was passed by the specific column definition
+      * when extending [[AbstractColumn[_]] as this will tell us the Scala output type
+      * of the given column.
+      * We create a list of these types and if they match the case class types expected,
+      * it means we can auto-generate a fromRow implementation.
+      */
     val colMembers = sourceMembers.map { member =>
       val memberType = member.typeSignatureIn(tableTpe)
 
       memberType.baseClasses.find(colSymbol ==) match {
-        case Some(root) => {
-
-          println(root.asType.typeSignature.widen.dealias.typeArgs)
-
-          root.typeSignatureIn(memberType).typeArgs.headOption match {
-            case Some(colSignature) => colSignature
-            case None => c.abort(
-              c.enclosingPosition,
-              s"Could not find the type argument passed to AbstractColumn for ${member.asModule.name}"
-            )
+        case Some(root) =>
+          // Here we expect to have a single type argument or type param
+          // because we know root here will point to an AbstractColumn[_] symbol.
+          root.typeSignature.typeParams match {
+            // We use the special API to see what type was passed through to AbstractColumn[_]
+            // with special thanks to https://github.com/joroKr21 for helping me not rip
+            // the remainder of my hair off while uncovering this marvelous macro API method.
+            case head :: Nil => head.asType.toType.asSeenFrom(memberType, colSymbol)
+            case _ => c.abort(c.enclosingPosition, "Expected exactly one type parameter provided for root column type")
           }
-        }
         case None => c.abort(c.enclosingPosition, s"Could not find root column type for ${member.asModule.name}")
       }
     }
 
-    Console.println("The column types in the type tree")
-    Console.println(colMembers.map(_.typeSymbol.name.decodedName.toString).mkString("\n"))
-    Console.println("The records types in the type tree")
-    Console.println(records.map(_.typeSymbol.name.decodedName.toString).mkString("\n"))
+    val recordMembersSet = recordMembers.to[ListSet]
 
-    val methodTree = q"""
-      null.asInstanceOf[$recordTpe]
-    """
+    Console.println(s"The ${recordMembersSet.size} case class types")
+    Console.println(recordMembersSet.map(_.typeSymbol.fullName).mkString("\n"))
 
-    println(showCode(methodTree))
-    methodTree
+    Console.println(s"The ${colMembers.size} output types inferred from the schema definition")
+    Console.println(colMembers.map(_.typeSymbol.fullName).mkString("\n"))
+
+    val tree = q"""new ${recordTpe}(..$columnNames)"""
+
+    println(showCode(tree))
+    tree
   }
 
 
@@ -153,9 +206,7 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
        new com.outworkers.phantom.macros.TableHelper[$tpe, $rTpe] {
           def tableName: $strTpe = $finalName
 
-          def fromRow(row: $rowType): $rTpe = {
-            return ${materializeExtractor[T, R]}
-          }
+          def fromRow(row: $rowType): $rTpe = ${materializeExtractor[T, R]}
 
           def fields(table: $tableTpe): scala.collection.immutable.Set[$colTpe] = {
             scala.collection.immutable.Set.apply[$colTpe](..$accessors)

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -253,7 +253,7 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
           }
        }
      """
-    Console.println(tree)
+    //Console.println(tree)
     tree
   }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/BasicTableMethods.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/BasicTableMethods.scala
@@ -36,14 +36,4 @@ class BasicTableMethods extends FlatSpec with Matchers {
   it should "retrieve the correct number of clustering keys for a table" in {
     TestDatabase.clusteringTable.clusteringColumns.size shouldEqual 2
   }
-
-  it should "create the correct CLUSTERING_ORDER key for a 3 part clustering key" in {
-    val key = TestDatabase.clusteringTable.clusteringKey
-    key shouldEqual "WITH CLUSTERING ORDER BY (id2 ASC, id3 DESC)"
-  }
-
-  it should "create the correct CLUSTERING_ORDER key for a 2 part clustering key" in {
-    val key = TestDatabase.complexClusteringTable.clusteringKey
-    key shouldEqual "WITH CLUSTERING ORDER BY (id2 ASC, id3 DESC, placeholder DESC)"
-  }
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/DistinctTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/DistinctTest.scala
@@ -31,10 +31,10 @@ class DistinctTest extends PhantomSuite {
 
   it should "return distinct primary keys" in {
     val rows = List(
-      StubRecord("a", UUID.nameUUIDFromBytes("1".getBytes)),
-      StubRecord("b", UUID.nameUUIDFromBytes("1".getBytes)),
-      StubRecord("c", UUID.nameUUIDFromBytes("2".getBytes)),
-      StubRecord("d", UUID.nameUUIDFromBytes("3".getBytes))
+      StubRecord(UUID.nameUUIDFromBytes("1".getBytes), "a"),
+      StubRecord(UUID.nameUUIDFromBytes("1".getBytes), "b"),
+      StubRecord(UUID.nameUUIDFromBytes("2".getBytes), "c"),
+      StubRecord(UUID.nameUUIDFromBytes("3".getBytes), "d")
     )
 
     val batch = rows.foldLeft(Batch.unlogged)((batch, row) => {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilderTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilderTest.scala
@@ -40,7 +40,7 @@ class CreateQueryBuilderTest extends FreeSpec with Matchers with SerializationTe
   "The CREATE query builder" - {
 
     "should correctly serialise primary key definitions" - {
-      "a simple single partition key defintion" in {
+      "a simple single partition key definition" in {
         val cols = List("test")
         QueryBuilder.Create.primaryKey(cols).queryString shouldEqual "PRIMARY KEY (test)"
       }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilderTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/serializers/CreateQueryBuilderTest.scala
@@ -39,6 +39,20 @@ class CreateQueryBuilderTest extends FreeSpec with Matchers with SerializationTe
 
   "The CREATE query builder" - {
 
+    "should correctly serialise primary key definitions" - {
+      "a simple single partition key defintion" in {
+        val cols = List("test")
+        QueryBuilder.Create.primaryKey(cols).queryString shouldEqual "PRIMARY KEY (test)"
+      }
+
+      "a single partition key and a primary key" in {
+        val partitions = List("test")
+        val primaries = List("test2")
+        QueryBuilder.Create.primaryKey(partitions, primaries).queryString shouldEqual "PRIMARY KEY (test, test2)"
+      }
+    }
+
+
     "should allow using DateTieredCompactionStrategy and its options" - {
       "serialise a create query with a DateTieredCompactionStrategy" in {
         val qb = BasicTable.create.`with`(

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/database/DatabaseTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/database/DatabaseTest.scala
@@ -19,15 +19,16 @@ import com.outworkers.phantom.PhantomSuite
 import com.outworkers.phantom.dsl._
 import com.outworkers.util.testing._
 
+object db extends TestDatabase
+
 class DatabaseTest extends PhantomSuite {
-  object db extends TestDatabase
 
   it should "instantiate a database and collect references to the tables" in {
     db.tables.size shouldEqual 4
   }
 
   it should "automatically generate the CQL schema and initialise tables " in {
-    db.autocreate().future().successful {
+    db.createAsync().successful {
       res => res.nonEmpty shouldEqual true
     }
   }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/database/TestDatabase.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/database/TestDatabase.scala
@@ -23,10 +23,10 @@ private[this] object DefaultKeyspace {
 }
 
 class TestDatabase extends Database[TestDatabase](DefaultKeyspace.local) {
-  object enumTable extends EnumTable with connector.Connector
-  object basicTable extends BasicTable with connector.Connector
-  object jsonTable extends JsonTable with connector.Connector
-  object recipes extends Recipes with connector.Connector
+  object enumTable extends EnumTable with Connector
+  object basicTable extends BasicTable with Connector
+  object jsonTable extends JsonTable with Connector
+  object recipes extends Recipes with Connector
 }
 
 object TestDatabase extends TestDatabase

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
@@ -133,20 +133,6 @@ sealed class ComplexClusteringTable extends CassandraTable[ConcreteComplexCluste
 
 abstract class ConcreteComplexClusteringTable extends ComplexClusteringTable with RootConnector
 
-
-sealed class BrokenClusteringTable extends CassandraTable[ConcreteBrokenClusteringTable, String] {
-  object id extends UUIDColumn(this) with PartitionKey
-
-  object id2 extends UUIDColumn(this) with PrimaryKey
-  object id3 extends UUIDColumn(this) with ClusteringOrder with Descending
-  object placeholder extends StringColumn(this) with ClusteringOrder with Descending
-
-  override def fromRow(r: Row): String = placeholder(r)
-}
-
-abstract class ConcreteBrokenClusteringTable extends BrokenClusteringTable
-
-
 sealed class ComplexCompoundKeyTable extends CassandraTable[ConcreteComplexCompoundKeyTable, String] {
 
   object id extends UUIDColumn(this) with PartitionKey

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
@@ -19,7 +19,7 @@ import com.outworkers.phantom.connectors.RootConnector
 import com.outworkers.phantom.builder.query.InsertQuery
 import com.outworkers.phantom.dsl._
 
-class BasicTable extends CassandraTable[ConcreteBasicTable, String] {
+abstract class BasicTable extends CassandraTable[BasicTable, String] with RootConnector {
 
   object id extends UUIDColumn(this) with PartitionKey
   object id2 extends UUIDColumn(this) with PrimaryKey
@@ -28,9 +28,6 @@ class BasicTable extends CassandraTable[ConcreteBasicTable, String] {
 
   override def fromRow(r: Row): String = placeholder(r)
 }
-
-abstract class ConcreteBasicTable extends BasicTable with RootConnector
-
 
 trait Records extends Enumeration {
   type Records = Value
@@ -64,14 +61,12 @@ case class NamedPartitionRecord(
   id: UUID
 )
 
-abstract class EnumTable extends CassandraTable[ConcreteEnumTable, EnumRecord] {
+abstract class EnumTable extends CassandraTable[EnumTable, EnumRecord] with RootConnector {
   object id extends StringColumn(this) with PartitionKey
   object enum extends EnumColumn[Records#Value](this)
   object optEnum extends OptionalEnumColumn[Records#Value](this)
-}
 
-abstract class ConcreteEnumTable extends EnumTable with RootConnector {
-  def store(sample: EnumRecord): InsertQuery.Default[ConcreteEnumTable, EnumRecord] = {
+  def store(sample: EnumRecord): InsertQuery.Default[EnumTable, EnumRecord] = {
     insert
       .value(_.id, sample.name)
       .value(_.enum, sample.enum)

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/BasicTable.scala
@@ -26,7 +26,7 @@ class BasicTable extends CassandraTable[ConcreteBasicTable, String] {
   object id3 extends UUIDColumn(this) with PrimaryKey
   object placeholder extends StringColumn(this)
 
-  def fromRow(r: Row): String = placeholder(r)
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteBasicTable extends BasicTable with RootConnector
@@ -68,14 +68,6 @@ abstract class EnumTable extends CassandraTable[ConcreteEnumTable, EnumRecord] {
   object id extends StringColumn(this) with PartitionKey
   object enum extends EnumColumn[Records#Value](this)
   object optEnum extends OptionalEnumColumn[Records#Value](this)
-
-  def fromRow(row: Row): EnumRecord = {
-    EnumRecord(
-      name = id(row),
-      enum = enum(row),
-      optEnum = optEnum(row)
-    )
-  }
 }
 
 abstract class ConcreteEnumTable extends EnumTable with RootConnector {
@@ -92,14 +84,6 @@ sealed class NamedEnumTable extends CassandraTable[ConcreteNamedEnumTable, Named
   object id extends StringColumn(this) with PartitionKey
   object enum extends EnumColumn[NamedRecords#Value](this)
   object optEnum extends OptionalEnumColumn[NamedRecords#Value](this)
-
-  def fromRow(row: Row): NamedEnumRecord = {
-    NamedEnumRecord(
-      id(row),
-      enum(row),
-      optEnum(row)
-    )
-  }
 }
 
 abstract class ConcreteNamedEnumTable extends NamedEnumTable with RootConnector {
@@ -115,13 +99,6 @@ abstract class ConcreteNamedEnumTable extends NamedEnumTable with RootConnector 
 sealed class NamedPartitionEnumTable extends CassandraTable[ConcreteNamedPartitionEnumTable, NamedPartitionRecord] {
   object enum extends EnumColumn[NamedRecords#Value](this) with PartitionKey
   object id extends UUIDColumn(this) with PrimaryKey
-
-  def fromRow(row: Row): NamedPartitionRecord = {
-    NamedPartitionRecord(
-      enum = enum(row),
-      id = id(row)
-    )
-  }
 }
 
 abstract class ConcreteNamedPartitionEnumTable extends NamedPartitionEnumTable with RootConnector {
@@ -132,8 +109,6 @@ abstract class ConcreteNamedPartitionEnumTable extends NamedPartitionEnumTable w
   }
 }
 
-
-
 sealed class ClusteringTable extends CassandraTable[ConcreteClusteringTable, String] {
 
   object id extends UUIDColumn(this) with PartitionKey
@@ -141,9 +116,7 @@ sealed class ClusteringTable extends CassandraTable[ConcreteClusteringTable, Str
   object id3 extends UUIDColumn(this) with ClusteringOrder with Descending
   object placeholder extends StringColumn(this)
 
-  def fromRow(r: Row): String = {
-    placeholder(r)
-  }
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteClusteringTable extends ClusteringTable with RootConnector
@@ -155,9 +128,7 @@ sealed class ComplexClusteringTable extends CassandraTable[ConcreteComplexCluste
   object id3 extends UUIDColumn(this) with ClusteringOrder with Descending
   object placeholder extends StringColumn(this) with ClusteringOrder with Descending
 
-  def fromRow(r: Row): String = {
-    placeholder(r)
-  }
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteComplexClusteringTable extends ComplexClusteringTable with RootConnector
@@ -170,9 +141,7 @@ sealed class BrokenClusteringTable extends CassandraTable[ConcreteBrokenClusteri
   object id3 extends UUIDColumn(this) with ClusteringOrder with Descending
   object placeholder extends StringColumn(this) with ClusteringOrder with Descending
 
-  def fromRow(r: Row): String = {
-    placeholder(r)
-  }
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteBrokenClusteringTable extends BrokenClusteringTable
@@ -191,9 +160,7 @@ sealed class ComplexCompoundKeyTable extends CassandraTable[ConcreteComplexCompo
   object id9 extends UUIDColumn(this) with PrimaryKey
   object placeholder extends StringColumn(this)
 
-  def fromRow(r: Row): String = {
-    placeholder(r)
-  }
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteComplexCompoundKeyTable extends ComplexCompoundKeyTable with RootConnector
@@ -205,9 +172,7 @@ sealed class SimpleCompoundKeyTable extends CassandraTable[ConcreteSimpleCompoun
   object id3 extends UUIDColumn(this) with PrimaryKey
   object placeholder extends StringColumn(this)
 
-  def fromRow(r: Row): String = {
-    placeholder(r)
-  }
+  override def fromRow(r: Row): String = placeholder(r)
 }
 
 abstract class ConcreteSimpleCompoundKeyTable extends SimpleCompoundKeyTable with RootConnector

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/CounterTableTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/CounterTableTest.scala
@@ -25,13 +25,6 @@ class CounterTableTest extends CassandraTable[ConcreteCounterTableTest, CounterR
 
   object id extends UUIDColumn(this) with PartitionKey
   object count_entries extends CounterColumn(this)
-
-  def fromRow(row: Row): CounterRecord = {
-    CounterRecord(
-      id = id(row),
-      count = count_entries(row)
-    )
-  }
 }
 
 abstract class ConcreteCounterTableTest extends CounterTableTest with RootConnector {
@@ -41,13 +34,6 @@ abstract class ConcreteCounterTableTest extends CounterTableTest with RootConnec
 class SecondaryCounterTable extends CassandraTable[ConcreteSecondaryCounterTable, CounterRecord] {
   object id extends UUIDColumn(this) with PartitionKey
   object count_entries extends CounterColumn(this)
-
-  def fromRow(row: Row): CounterRecord = {
-    CounterRecord(
-      id = id(row),
-      count = count_entries(row)
-    )
-  }
 }
 
 abstract class ConcreteSecondaryCounterTable extends SecondaryCounterTable with RootConnector {
@@ -58,13 +44,6 @@ class BrokenCounterTableTest extends CassandraTable[ConcreteBrokenCounterTableTe
 
   object id extends UUIDColumn(this) with PartitionKey
   object count_entries extends CounterColumn(this)
-
-  def fromRow(row: Row): CounterRecord = {
-    CounterRecord(
-      id = id(row),
-      count = count_entries(row)
-    )
-  }
 
 }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/IndexedCollectionsTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/IndexedCollectionsTable.scala
@@ -36,18 +36,6 @@ sealed class IndexedCollectionsTable extends CassandraTable[ConcreteIndexedColle
   object mapIntToText extends MapColumn[Int, String](this) with Index with Keys
 
   object mapIntToInt extends MapColumn[Int, Int](this)
-
-  def fromRow(r: Row): TestRow = {
-    TestRow(
-      key = key(r),
-      list = list(r),
-      setText = setText(r),
-      mapTextToText = mapTextToText(r),
-      setInt = setInt(r),
-      mapIntToText = mapIntToText(r),
-      mapIntToInt = mapIntToInt(r)
-    )
-  }
 }
 
 abstract class ConcreteIndexedCollectionsTable extends IndexedCollectionsTable with RootConnector {
@@ -82,18 +70,6 @@ sealed class IndexedEntriesTable extends CassandraTable[ConcreteIndexedEntriesTa
   object mapIntToText extends MapColumn[Int, String](this) with Index with Keys
 
   object mapIntToInt extends MapColumn[Int, Int](this) with Index with Entries
-
-  def fromRow(r: Row): TestRow = {
-    TestRow(
-      key = key(r),
-      list = list(r),
-      setText = setText(r),
-      mapTextToText = mapTextToText(r),
-      setInt = setInt(r),
-      mapIntToText = mapIntToText(r),
-      mapIntToInt = mapIntToInt(r)
-    )
-  }
 }
 
 abstract class ConcreteIndexedEntriesTable extends IndexedEntriesTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/JsonTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/JsonTable.scala
@@ -69,16 +69,6 @@ class JsonTable extends CassandraTable[ConcreteJsonTable, JsonClass] {
       compactRender(Extraction.decompose(obj))
     }
   }
-
-  def fromRow(row: Row): JsonClass = {
-    JsonClass(
-      id = id(row),
-      name = name(row),
-      json = json(row),
-      jsonList = jsonList(row),
-      jsonSet = jsonSet(row)
-    )
-  }
 }
 
 abstract class ConcreteJsonTable extends JsonTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/JsonTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/JsonTable.scala
@@ -32,7 +32,7 @@ case class JsonClass(
 )
 
 
-class JsonTable extends CassandraTable[ConcreteJsonTable, JsonClass] {
+abstract class JsonTable extends CassandraTable[JsonTable, JsonClass] with RootConnector {
 
   implicit val formats = DefaultFormats
 
@@ -69,10 +69,8 @@ class JsonTable extends CassandraTable[ConcreteJsonTable, JsonClass] {
       compactRender(Extraction.decompose(obj))
     }
   }
-}
 
-abstract class ConcreteJsonTable extends JsonTable with RootConnector {
-  def store(sample: JsonClass): InsertQuery.Default[ConcreteJsonTable, JsonClass] = {
+  def store(sample: JsonClass): InsertQuery.Default[JsonTable, JsonClass] = {
     insert
       .value(_.id, sample.id)
       .value(_.name, sample.name)

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
@@ -27,13 +27,6 @@ case class MyTestRow(
 )
 
 sealed class ListCollectionTable extends CassandraTable[ConcreteListCollectionTable, MyTestRow] {
-  def fromRow(r: Row): MyTestRow = {
-    MyTestRow(
-      key(r),
-      optionA(r),
-      stringlist(r)
-    )
-  }
 
   object key extends StringColumn(this) with PartitionKey
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
@@ -31,9 +31,8 @@ sealed class ListCollectionTable extends CassandraTable[ConcreteListCollectionTa
   object key extends StringColumn(this) with PartitionKey
 
   object optionA extends OptionalIntColumn(this)
-  
-  object stringlist extends ListColumn[String](this)
 
+  object stringlist extends ListColumn[String](this)
 }
 
 abstract class ConcreteListCollectionTable extends ListCollectionTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/ListCollectionTable.scala
@@ -30,9 +30,9 @@ sealed class ListCollectionTable extends CassandraTable[ConcreteListCollectionTa
 
   object key extends StringColumn(this) with PartitionKey
 
-  object stringlist extends ListColumn[String](this)
-
   object optionA extends OptionalIntColumn(this)
+  
+  object stringlist extends ListColumn[String](this)
 
 }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/MultipleKeys.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/MultipleKeys.scala
@@ -31,7 +31,7 @@ class MultipleKeys extends CassandraTable[ConcreteMultipleKeys, Option[MultipleK
   object intColumn7 extends IntColumn(this) with PrimaryKey
   object timestamp8 extends DateTimeColumn(this)
 
-  def fromRow(r: Row): Option[MultipleKeys] = None
+  override def fromRow(r: Row): Option[MultipleKeys] = None
 }
 
 abstract class ConcreteMultipleKeys extends MultipleKeys with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/OptionalSecondaryIndexTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/OptionalSecondaryIndexTable.scala
@@ -27,17 +27,12 @@ case class OptionalSecondaryRecord(
   secondary: Option[Int]
 )
 
-sealed class OptionalSecondaryIndexTable extends
-  CassandraTable[ConcreteOptionalSecondaryIndexTable, OptionalSecondaryRecord] {
+sealed class OptionalSecondaryIndexTable extends CassandraTable[
+  ConcreteOptionalSecondaryIndexTable,
+  OptionalSecondaryRecord
+] {
   object id extends UUIDColumn(this) with PartitionKey
   object secondary extends OptionalIntColumn(this) with Index
-
-  def fromRow(row: Row): OptionalSecondaryRecord = {
-    OptionalSecondaryRecord(
-      id(row),
-      secondary(row)
-    )
-  }
 }
 
 abstract class ConcreteOptionalSecondaryIndexTable

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/PrimaryCollectionTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/PrimaryCollectionTable.scala
@@ -34,16 +34,6 @@ class PrimaryCollectionTable extends CassandraTable[ConcretePrimaryCollectionTab
   object mapCol extends MapColumn[String, String](this) with PrimaryKey
   object name extends StringColumn(this) with PrimaryKey
   object value extends IntColumn(this)
-
-  def fromRow(row: Row): PrimaryCollectionRecord = {
-    PrimaryCollectionRecord(
-      listIndex(row),
-      setCol(row),
-      mapCol(row),
-      name(row),
-      value(row)
-    )
-  }
 }
 
 abstract class ConcretePrimaryCollectionTable extends PrimaryCollectionTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/Recipes.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/Recipes.scala
@@ -32,7 +32,7 @@ case class Recipe(
   uid: UUID
 )
 
-class Recipes extends CassandraTable[ConcreteRecipes, Recipe] {
+abstract class Recipes extends CassandraTable[Recipes, Recipe] with RootConnector {
 
   object url extends StringColumn(this) with PartitionKey
 
@@ -47,11 +47,8 @@ class Recipes extends CassandraTable[ConcreteRecipes, Recipe] {
   object props extends MapColumn[String, String](this)
 
   object uid extends UUIDColumn(this)
-}
 
-abstract class ConcreteRecipes extends Recipes with RootConnector {
-
-  def store(recipe: Recipe): InsertQuery.Default[ConcreteRecipes, Recipe] = {
+  def store(recipe: Recipe): InsertQuery.Default[Recipes, Recipe] = {
     insert
       .value(_.url, recipe.url)
       .value(_.description, recipe.description)

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/Recipes.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/Recipes.scala
@@ -47,19 +47,6 @@ class Recipes extends CassandraTable[ConcreteRecipes, Recipe] {
   object props extends MapColumn[String, String](this)
 
   object uid extends UUIDColumn(this)
-
-
-  override def fromRow(r: Row): Recipe = {
-    Recipe(
-      url(r),
-      description(r),
-      ingredients(r),
-      servings(r),
-      lastcheckedat(r),
-      props(r),
-      uid(r)
-    )
-  }
 }
 
 abstract class ConcreteRecipes extends Recipes with RootConnector {
@@ -76,21 +63,11 @@ abstract class ConcreteRecipes extends Recipes with RootConnector {
   }
 }
 
-
 case class SampleEvent(id: UUID, map: Map[Long, DateTime])
 
 sealed class Events extends CassandraTable[ConcreteEvents, SampleEvent]  {
-
   object id extends UUIDColumn(this) with PartitionKey
-
   object map extends MapColumn[Long, DateTime](this)
-
-  def fromRow(row: Row): SampleEvent = {
-    SampleEvent(
-      id = id(row),
-      map = map(row)
-    )
-  }
 }
 
 abstract class ConcreteEvents extends Events with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/SecondaryIndexTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/SecondaryIndexTable.scala
@@ -26,18 +26,9 @@ import com.outworkers.phantom.dsl._
 )
 
 sealed class SecondaryIndexTable extends CassandraTable[ConcreteSecondaryIndexTable, SecondaryIndexRecord] {
-
   object id extends UUIDColumn(this) with PartitionKey
   object secondary extends UUIDColumn(this) with Index
   object name extends StringColumn(this)
-
-  def fromRow(r: Row): SecondaryIndexRecord = {
-    SecondaryIndexRecord(
-      primary = id(r),
-      secondary = secondary(r),
-      name = name(r)
-    )
-  }
 }
 
 abstract class ConcreteSecondaryIndexTable extends SecondaryIndexTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/StaticTableTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/StaticTableTest.scala
@@ -24,17 +24,8 @@ case class StaticCollectionSingle(id: UUID, clusteringId: UUID, static: String)
 sealed class StaticTableTest extends CassandraTable[ConcreteStaticTableTest, StaticCollectionSingle] {
 
   object id extends UUIDColumn(this) with PartitionKey
-
   object clusteringId extends UUIDColumn(this) with PrimaryKey with ClusteringOrder with Descending
   object staticTest extends StringColumn(this) with StaticColumn
-
-  def fromRow(row: Row): StaticCollectionSingle = {
-    StaticCollectionSingle(
-      id(row),
-      clusteringId(row),
-      staticTest(row)
-    )
-  }
 }
 
 abstract class ConcreteStaticTableTest extends StaticTableTest with RootConnector
@@ -49,17 +40,8 @@ case class StaticCollectionRecord(
 sealed class StaticCollectionTableTest extends CassandraTable[ConcreteStaticCollectionTableTest, StaticCollectionRecord] {
 
   object id extends UUIDColumn(this) with PartitionKey
-
   object clusteringId extends UUIDColumn(this) with PrimaryKey with ClusteringOrder with Descending
   object staticList extends ListColumn[String](this) with StaticColumn
-
-  def fromRow(row: Row): StaticCollectionRecord = {
-    StaticCollectionRecord(
-      id = id(row),
-      clustering = clusteringId(row),
-      list = staticList(row)
-    )
-  }
 }
 
 abstract class ConcreteStaticCollectionTableTest extends StaticCollectionTableTest with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TableKeyTests.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TableKeyTests.scala
@@ -18,15 +18,15 @@ package com.outworkers.phantom.tables
 import com.outworkers.phantom.connectors.RootConnector
 import com.outworkers.phantom.dsl._
 
-case class StubRecord(name: String, id: UUID)
+case class StubRecord(
+  id: UUID,
+  name: String
+)
+
 sealed class TableWithSingleKey extends CassandraTable[ConcreteTableWithSingleKey, StubRecord] {
 
   object id extends UUIDColumn(this) with PartitionKey
   object name extends StringColumn(this)
-
-  def fromRow(r: Row): StubRecord = {
-    StubRecord(name(r), id(r))
-  }
 }
 
 abstract class ConcreteTableWithSingleKey extends TableWithSingleKey with RootConnector
@@ -37,9 +37,7 @@ class TableWithCompoundKey extends CassandraTable[ConcreteTableWithCompoundKey, 
   object second extends UUIDColumn(this) with PrimaryKey
   object name extends StringColumn(this)
 
-  def fromRow(r: Row): StubRecord = {
-    StubRecord(name(r), id(r))
-  }
+  override def fromRow(r: Row): StubRecord = StubRecord(id(r), name(r))
 }
 
 abstract class ConcreteTableWithCompoundKey extends TableWithCompoundKey with RootConnector
@@ -52,10 +50,10 @@ sealed class TableWithCompositeKey extends CassandraTable[ConcreteTableWithCompo
   object second extends UUIDColumn(this) with PrimaryKey
   object name extends StringColumn(this)
 
-  def fromRow(r: Row): StubRecord = {
+  override def fromRow(r: Row): StubRecord = {
     StubRecord(
-      name = name(r),
-      id = id(r)
+      id = id(r),
+      name = name(r)
     )
   }
 }
@@ -63,16 +61,8 @@ sealed class TableWithCompositeKey extends CassandraTable[ConcreteTableWithCompo
 abstract class ConcreteTableWithCompositeKey extends TableWithCompositeKey with RootConnector
 
 sealed class TableWithNoKey extends CassandraTable[ConcreteTableWithNoKey, StubRecord] {
-
   object id extends UUIDColumn(this)
   object name extends StringColumn(this)
-
-  def fromRow(r: Row): StubRecord = {
-    StubRecord(
-      name = name(r),
-      id = id(r)
-    )
-  }
 }
 
 abstract class ConcreteTableWithNoKey extends TableWithNoKey with RootConnector

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TableKeyTests.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TableKeyTests.scala
@@ -60,9 +60,4 @@ sealed class TableWithCompositeKey extends CassandraTable[ConcreteTableWithCompo
 
 abstract class ConcreteTableWithCompositeKey extends TableWithCompositeKey with RootConnector
 
-sealed class TableWithNoKey extends CassandraTable[ConcreteTableWithNoKey, StubRecord] {
-  object id extends UUIDColumn(this)
-  object name extends StringColumn(this)
-}
 
-abstract class ConcreteTableWithNoKey extends TableWithNoKey with RootConnector

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
@@ -28,8 +28,8 @@ class TestDatabase(override val connector: CassandraConnection) extends Database
   object articles extends ConcreteArticles with connector.Connector
   object articlesByAuthor extends ConcreteArticlesByAuthor with connector.Connector
 
-  object basicTable extends ConcreteBasicTable with connector.Connector
-  object enumTable extends ConcreteEnumTable with connector.Connector
+  object basicTable extends BasicTable with connector.Connector
+  object enumTable extends EnumTable with connector.Connector
   object namedEnumTable extends ConcreteNamedEnumTable with connector.Connector
   object indexedEnumTable extends ConcreteNamedPartitionEnumTable with connector.Connector
 
@@ -44,7 +44,7 @@ class TestDatabase(override val connector: CassandraConnection) extends Database
 
   object indexedCollectionsTable extends ConcreteIndexedCollectionsTable with connector.Connector
   object indexedEntriesTable extends ConcreteIndexedEntriesTable with connector.Connector
-  object jsonTable extends ConcreteJsonTable with connector.Connector
+  object jsonTable extends JsonTable with connector.Connector
   object listCollectionTable extends ConcreteListCollectionTable with connector.Connector
   object optionalPrimitives extends ConcreteOptionalPrimitives with connector.Connector
   object primitives extends ConcretePrimitives with connector.Connector

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
@@ -54,8 +54,8 @@ class TestDatabase(override val connector: CassandraConnection) extends Database
   object primitivesCassandra22 extends ConcretePrimitivesCassandra22 with connector.Connector
   object optionalPrimitivesCassandra22 extends ConcreteOptionalPrimitivesCassandra22 with connector.Connector
 
-  object recipes extends ConcreteRecipes with connector.Connector {
-    override def autocreate(space: KeySpace): CreateQuery.Default[ConcreteRecipes, Recipe] = {
+  object recipes extends Recipes with connector.Connector {
+    override def autocreate(space: KeySpace): CreateQuery.Default[Recipes, Recipe] = {
       create.ifNotExists()(space).`with`(comment eqs "This is a test string")
     }
   }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestDatabase.scala
@@ -35,7 +35,6 @@ class TestDatabase(override val connector: CassandraConnection) extends Database
 
   object clusteringTable extends ConcreteClusteringTable with connector.Connector
   object complexClusteringTable extends ConcreteComplexClusteringTable with connector.Connector
-  object brokenClusteringTable extends ConcreteBrokenClusteringTable with connector.Connector
   object simpleCompoundKeyTable extends ConcreteSimpleCompoundKeyTable with connector.Connector
   object complexCompoundKeyTable extends ConcreteComplexCompoundKeyTable with connector.Connector
 
@@ -68,7 +67,6 @@ class TestDatabase(override val connector: CassandraConnection) extends Database
   object tableWithSingleKey extends ConcreteTableWithSingleKey with connector.Connector
   object tableWithCompoundKey extends ConcreteTableWithCompoundKey with connector.Connector
   object tableWithCompositeKey extends ConcreteTableWithCompositeKey with connector.Connector
-  object tableWithNoKey extends ConcreteTableWithNoKey with connector.Connector
 
   object testTable extends ConcreteTestTable with connector.Connector
   object timeSeriesTable extends ConcreteTimeSeriesTable with connector.Connector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestTable.scala
@@ -42,18 +42,6 @@ sealed class TestTable extends CassandraTable[ConcreteTestTable, TestRow] {
   object setInt extends SetColumn[Int](this)
 
   object mapIntToText extends MapColumn[Int, String](this)
-
-  def fromRow(r: Row): TestRow = {
-    TestRow(
-      key = key(r),
-      list = list(r),
-      setText = setText(r),
-      mapTextToText = mapTextToText(r),
-      setInt = setInt(r),
-      mapIntToText = mapIntToText(r),
-      mapIntToInt = Map.empty[Int, Int]
-    )
-  }
 }
 
 abstract class ConcreteTestTable extends TestTable with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TestTable.scala
@@ -42,6 +42,8 @@ sealed class TestTable extends CassandraTable[ConcreteTestTable, TestRow] {
   object setInt extends SetColumn[Int](this)
 
   object mapIntToText extends MapColumn[Int, String](this)
+
+  object mapIntToInt extends MapColumn[Int, Int](this)
 }
 
 abstract class ConcreteTestTable extends TestTable with RootConnector {
@@ -55,6 +57,7 @@ abstract class ConcreteTestTable extends TestTable with RootConnector {
       .value(_.mapTextToText, row.mapTextToText)
       .value(_.setInt, row.setInt)
       .value(_.mapIntToText, row.mapIntToText)
+      .value(_.mapIntToInt, row.mapIntToInt)
   }
 
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TimeSeriesTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TimeSeriesTable.scala
@@ -42,14 +42,6 @@ sealed class TimeSeriesTable extends CassandraTable[ConcreteTimeSeriesTable, Tim
   object timestamp extends DateTimeColumn(this) with ClusteringOrder with Descending {
     override val name = "unixTimestamp"
   }
-
-  def fromRow(row: Row): TimeSeriesRecord = {
-    TimeSeriesRecord(
-      id(row),
-      name(row),
-      timestamp(row)
-    )
-  }
 }
 
 abstract class ConcreteTimeSeriesTable extends TimeSeriesTable with RootConnector
@@ -60,7 +52,7 @@ sealed class TimeUUIDTable extends CassandraTable[ConcreteTimeUUIDTable, TimeUUI
   object id extends TimeUUIDColumn(this) with ClusteringOrder with Descending
   object name extends StringColumn(this)
 
-  def fromRow(row: Row): TimeUUIDRecord = {
+  override def fromRow(row: Row): TimeUUIDRecord = {
     TimeUUIDRecord(
       user(row),
       id(row),

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TimeSeriesTableWithTTL.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TimeSeriesTableWithTTL.scala
@@ -24,14 +24,6 @@ sealed class TimeSeriesTableWithTTL extends CassandraTable[ConcreteTimeSeriesTab
   object id extends UUIDColumn(this) with PartitionKey
   object name extends StringColumn(this)
   object timestamp extends DateTimeColumn(this) with ClusteringOrder with Descending
-
-  def fromRow(row: Row): TimeSeriesRecord = {
-    TimeSeriesRecord(
-      id(row),
-      name(row),
-      timestamp(row)
-    )
-  }
 }
 
 abstract class ConcreteTimeSeriesTableWithTTL extends TimeSeriesTableWithTTL with RootConnector
@@ -40,14 +32,6 @@ sealed class TimeSeriesTableWithTTL2 extends CassandraTable[ConcreteTimeSeriesTa
   object id extends UUIDColumn(this) with PartitionKey
   object name extends StringColumn(this)
   object timestamp extends DateTimeColumn(this)
-
-  def fromRow(row: Row): TimeSeriesRecord = {
-    TimeSeriesRecord(
-      id(row),
-      name(row),
-      timestamp(row)
-    )
-  }
 }
 
 abstract class ConcreteTimeSeriesTableWithTTL2 extends TimeSeriesTableWithTTL2 with RootConnector {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TupleColumnTable.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/TupleColumnTable.scala
@@ -27,13 +27,6 @@ case class TupleRecord(id: UUID, tp: (String, Long))
 class TupleColumnTable extends CassandraTable[ConcreteTupleColumnTable, TupleRecord] {
   object id extends UUIDColumn(this) with PartitionKey
   object tp extends TupleColumn[(String, Long)](this)
-
-  def fromRow(row: Row): TupleRecord = {
-    TupleRecord(
-      id(row),
-      tp(row)
-    )
-  }
 }
 
 abstract class ConcreteTupleColumnTable extends TupleColumnTable with RootConnector {
@@ -54,13 +47,6 @@ case class NestedTupleRecord(id: UUID, tp: (String, (String, Long)))
 class NestedTupleColumnTable extends CassandraTable[ConcreteNestedTupleColumnTable, NestedTupleRecord] {
   object id extends UUIDColumn(this) with PartitionKey
   object tp extends TupleColumn[(String, (String, Long))](this)
-
-  def fromRow(row: Row): NestedTupleRecord = {
-    NestedTupleRecord(
-      id(row),
-      tp(row)
-    )
-  }
 }
 
 abstract class ConcreteNestedTupleColumnTable extends NestedTupleColumnTable with RootConnector {
@@ -82,13 +68,6 @@ case class TupleCollectionRecord(id: UUID, tuples: List[(Int, String)])
 class TupleCollectionsTable extends CassandraTable[ConcreteTupleCollectionsTable, TupleCollectionRecord] {
   object id extends UUIDColumn(this) with PartitionKey
   object tuples extends ListColumn[(Int, String)](this)
-
-  def fromRow(row: Row): TupleCollectionRecord = {
-    TupleCollectionRecord(
-      id(row),
-      tuples(row)
-    )
-  }
 }
 
 abstract class ConcreteTupleCollectionsTable extends TupleCollectionsTable with RootConnector {

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/advanced/AdvancedRecipes.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/advanced/AdvancedRecipes.scala
@@ -53,21 +53,6 @@ sealed class AdvancedRecipes extends CassandraTable[ConcreteAdvancedRecipes, Rec
   object ingredients extends SetColumn[String](this)
   object props extends MapColumn[String, String](this)
   object timestamp extends DateTimeColumn(this) with ClusteringOrder
-
-  // Now the mapping function, transforming a row into a custom type.
-  // This is a bit of boilerplate, but it's one time only and very short.
-  def fromRow(row: Row): Recipe = {
-    Recipe(
-      id(row),
-      name(row),
-      title(row),
-      author(row),
-      description(row),
-      ingredients(row),
-      props(row),
-      timestamp(row)
-    )
-  }
 }
 
 

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/advanced/AdvancedRecipesByTitle.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/advanced/AdvancedRecipesByTitle.scala
@@ -37,10 +37,6 @@ sealed class AdvancedRecipesByTitle extends CassandraTable[ConcreteAdvancedRecip
 
   // The id is just another normal field.
   object id extends UUIDColumn(this)
-
-  def fromRow(row: Row): (String, UUID) = {
-    Tuple2(title(row), id(row))
-  }
 }
 
 abstract class ConcreteAdvancedRecipesByTitle extends AdvancedRecipesByTitle with RootConnector {

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/CompositeKeyRecipes.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/CompositeKeyRecipes.scala
@@ -52,21 +52,6 @@ sealed class CompositeKeyRecipes extends CassandraTable[ConcreteCompositeKeyReci
   object ingredients extends SetColumn[String](this)
   object props extends MapColumn[String, String](this)
   object timestamp extends DateTimeColumn(this)
-
-  // Now the mapping function, transforming a row into a custom type.
-  // This is a bit of boilerplate, but it's one time only and very short.
-  def fromRow(row: Row): Recipe = {
-    Recipe(
-      id(row),
-      name(row),
-      title(row),
-      author(row),
-      description(row),
-      ingredients(row),
-      props(row),
-      timestamp(row)
-    )
-  }
 }
 
 
@@ -91,5 +76,4 @@ abstract class ConcreteCompositeKeyRecipes extends CompositeKeyRecipes with Root
   def findRecipeByIdAndName(id: UUID, name: String): ScalaFuture[Option[Recipe]] = {
     select.where(_.id eqs id).and(_.name eqs name).one()
   }
-
 }

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/SecondaryKeyRecipes.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/SecondaryKeyRecipes.scala
@@ -51,21 +51,6 @@ sealed class SecondaryKeyRecipes extends CassandraTable[ConcreteSecondaryKeyReci
   object ingredients extends SetColumn[String](this)
   object props extends MapColumn[String, String](this)
   object timestamp extends DateTimeColumn(this)
-
-  // Now the mapping function, transforming a row into a custom type.
-  // This is a bit of boilerplate, but it's one time only and very short.
-  def fromRow(row: Row): Recipe = {
-    Recipe(
-      id(row),
-      name(row),
-      title(row),
-      author(row),
-      description(row),
-      ingredients(row),
-      props(row),
-      timestamp(row)
-    )
-  }
 }
 
 

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/SimpleRecipes.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/SimpleRecipes.scala
@@ -68,21 +68,6 @@ sealed class Recipes extends CassandraTable[Recipes, Recipe] {
   object props extends MapColumn[String, String](this)
 
   object timestamp extends DateTimeColumn(this)
-
-  // Now the mapping function, transforming a row into a custom type.
-  // This is a bit of boilerplate, but it's one time only and very short.
-  def fromRow(row: Row): Recipe = {
-    Recipe(
-      id(row),
-      name(row),
-      title(row),
-      author(row),
-      description(row),
-      ingredients(row),
-      props(row),
-      timestamp(row)
-    )
-  }
 }
 
 

--- a/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/ThriftModels.scala
+++ b/phantom-example/src/main/scala/com/outworkers/phantom/example/basics/ThriftModels.scala
@@ -29,7 +29,7 @@ case class SampleRecord(
   thriftModel: SampleModel
 )
 
-sealed class ThriftTable extends CassandraTable[ConcreteThriftTable,  SampleRecord] {
+sealed class ThriftTable extends CassandraTable[ConcreteThriftTable, SampleRecord] {
   object id extends UUIDColumn(this) with PartitionKey
   object stuff extends StringColumn(this)
   object someList extends ListColumn[String](this)
@@ -43,7 +43,7 @@ sealed class ThriftTable extends CassandraTable[ConcreteThriftTable,  SampleReco
     }
   }
 
-  def fromRow(r: Row): SampleRecord = {
+  override def fromRow(r: Row): SampleRecord = {
     SampleRecord(
       stuff = stuff(r),
       someList = someList(r),

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
@@ -309,14 +309,14 @@ package object finagle {
   ](val query: CreateQuery[Table, Record, Status]) extends AnyVal {
 
     def execute()(implicit session: Session, keySpace: KeySpace, executor: Executor): Future[ResultSet] = {
-      if (query.table.secondaryKeys.isEmpty) {
+      if (query.secondaryKeys.isEmpty) {
         twitterQueryStringExecuteToFuture(new SimpleStatement(query.qb.terminate().queryString))
       } else {
         query.execute() flatMap {
           res => {
             query.indexList(keySpace.name).execute() map {
               _ => {
-                Manager.logger.debug(s"Creating secondary indexes on ${QueryBuilder.keyspace(keySpace.name, query.table.tableName).queryString}")
+                Manager.logger.debug(s"Creating secondary indexes on ${QueryBuilder.keyspace(keySpace.name, query.tableName).queryString}")
                 res
               }
             }

--- a/phantom-reactivestreams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/CassandraTest.scala
+++ b/phantom-reactivestreams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/CassandraTest.scala
@@ -74,10 +74,6 @@ case class Opera(name: String)
 
 abstract class OperaTable extends CassandraTable[ConcreteOperaTable, Opera] {
   object name extends StringColumn(this) with PartitionKey
-
-  def fromRow(row: Row): Opera = {
-    Opera(name(row))
-  }
 }
 
 abstract class ConcreteOperaTable extends OperaTable with RootConnector {

--- a/phantom-reactivestreams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/CassandraTest.scala
+++ b/phantom-reactivestreams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/CassandraTest.scala
@@ -72,7 +72,7 @@ trait StreamTest extends FlatSpec with BeforeAndAfterAll
 
 case class Opera(name: String)
 
-abstract class OperaTable extends CassandraTable[ConcreteOperaTable, Opera] {
+class OperaTable extends CassandraTable[ConcreteOperaTable, Opera] {
   object name extends StringColumn(this) with PartitionKey
 }
 

--- a/phantom-thrift/src/test/scala/com/outworkers/phantom/tables/ThriftColumnTable.scala
+++ b/phantom-thrift/src/test/scala/com/outworkers/phantom/tables/ThriftColumnTable.scala
@@ -70,18 +70,6 @@ sealed class ThriftColumnTable extends CassandraTable[ConcreteThriftColumnTable,
       val codec = ThriftTest
     }
   }
-
-  def fromRow(row: Row): Output = {
-    Output(
-      id = id(row),
-      name = name(row),
-      struct = ref(row),
-      thriftSet = thriftSet(row),
-      thriftList = thriftList(row),
-      thriftMap = thriftMap(row),
-      optThrift = optionalThrift(row)
-    )
-  }
 }
 
 abstract class ConcreteThriftColumnTable extends ThriftColumnTable with RootConnector {
@@ -131,18 +119,6 @@ sealed class ThriftIndexedTable extends CassandraTable[ConcreteThriftIndexedTabl
     val serializer = new CompactThriftSerializer[ThriftTest] {
       val codec = ThriftTest
     }
-  }
-
-  def fromRow(row: Row): Output = {
-    Output(
-      id(row),
-      name(row),
-      ref(row),
-      thriftSet(row),
-      thriftList(row),
-      thriftMap(row),
-      optionalThrift(row)
-    )
   }
 }
 


### PR DESCRIPTION
- Adding ability to automatically infer the `fromRow` method inside CassandraTable during macro expansion for all columns and records that match in the order they are written. The output types of columns inside a table must match the field types of a `case class` for instance in the same order they are written.

- Manually merging in fix for injecting outer session provider instead of using self reference.