### PR TITLE
Feature/autogen store

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,8 @@ lazy val Versions = new {
   val cassandraUnit = "3.0.0.1"
   val javaxServlet = "3.0.1"
   val typesafeConfig = "1.3.1"
+  val joda = "2.9.4"
+  val jodaConvert = "1.8.1"
 
   val twitterUtilVersion: String => String = {
     s => CrossVersion.partialVersion(s) match {
@@ -183,11 +185,12 @@ lazy val phantomDsl = (project in file("phantom-dsl")).configs(
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     "com.outworkers"               %% "diesel-engine"                     % Versions.diesel,
     "com.chuusai"                  %% "shapeless"                         % Versions.shapeless,
-    "joda-time"                    %  "joda-time"                         % "2.9.4",
-    "org.joda"                     %  "joda-convert"                      % "1.8.1",
+    "joda-time"                    %  "joda-time"                         % Versions.joda,
+    "org.joda"                     %  "joda-convert"                      % Versions.jodaConvert,
     "com.datastax.cassandra"       %  "cassandra-driver-core"             % Versions.datastax,
     "com.datastax.cassandra"       %  "cassandra-driver-extras"           % Versions.datastax,
     "org.json4s"                   %% "json4s-native"                     % Versions.json4s,
+    "org.scalamock"                %% "scalamock-scalatest-support"       % "3.4.2"                         % Test,
     "org.scalacheck"               %% "scalacheck"                        % Versions.scalacheck             % Test,
     "com.outworkers"               %% "util-testing"                      % Versions.util                   % Test,
     "com.storm-enroute"            %% "scalameter"                        % Versions.scalameter             % Test,

--- a/build/publish_develop.sh
+++ b/build/publish_develop.sh
@@ -55,7 +55,18 @@ then
             echo "Bintray credentials still not found"
         fi
 
-        sbt version-bump-patch git-tag
+        COMMIT_MSG=$(git log -1 --pretty=%B 2>&1)
+        COMMIT_SKIP_MESSAGE = "[version skip]"
+
+        echo "Last commit message $COMMIT_MSG"
+
+        if [[ $COMMIT_MSG == *"${COMMIT_SKIP_MESSAGE}"* ]]
+        then
+            echo "Skipping version bump and simply tagging"
+            sbt git-tag
+        else
+            sbt version-bump-patch git-tag
+        fi
 
         echo "Pushing tag to GitHub."
         git push --tags "https://${github_token}@${GH_REF}"

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -93,6 +93,8 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
 
   final def insert()(implicit keySpace: KeySpace): InsertQuery.Default[T, R] = InsertQuery(instance)
 
+  final def store()(implicit keySpace: KeySpace): InsertQuery.Default[T, R] = helper.store(instance)
+
   final def delete()(implicit keySpace: KeySpace): DeleteQuery.Default[T, R] = DeleteQuery[T, R](instance)
 
   final def delete(

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/column/SetColumn.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/column/SetColumn.scala
@@ -50,9 +50,9 @@ abstract class AbstractSetColumn[Owner <: CassandraTable[Owner, Record], Record,
 class SetColumn[Owner <: CassandraTable[Owner, Record], Record, RR : Primitive](table: CassandraTable[Owner, Record])
     extends AbstractSetColumn[Owner, Record, RR](table) with PrimitiveCollectionValue[RR] {
 
-  override val valuePrimitive = Primitive[RR]
+  override val valuePrimitive: Primitive[RR] = Primitive[RR]
 
-  val cassandraType = QueryBuilder.Collections.setType(valuePrimitive.cassandraType).queryString
+  val cassandraType: String = QueryBuilder.Collections.setType(valuePrimitive.cassandraType).queryString
 
   override def qb: CQLQuery = {
     if (shouldFreeze) {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/MacroUtils.scala
@@ -20,7 +20,7 @@ import scala.reflect.macros.blackbox
 class MacroUtils(val c: blackbox.Context) {
   import c.universe._
 
-  def fields(tpe: Type): Iterable[(Name, Type)] = {
+  def caseFields(tpe: Type): Iterable[(Name, Type)] = {
     object CaseField {
       def unapply(arg: TermSymbol): Option[(Name, Type)] = {
         if (arg.isVal && arg.isCaseAccessor) {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -253,12 +253,11 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
       * First we create a set of ordered types corresponding to the type signatures
       * found in the case class arguments.
       */
-    val recordMembers = fields(recordTpe) map { case (nm, tp) => ColumnMember(nm.toTermName, tp) }
+    val recordMembers = caseFields(recordTpe) map { case (nm, tp) => ColumnMember(nm.toTermName, tp) }
 
     val colMembers = extractColumnMembers(tableTpe, columns)
 
     val tableSymbolName = tableTpe.typeSymbol.name
-
 
     findMatchingSubset(colMembers, recordMembers) match {
       case Match(results, _) if recordTpe.typeSymbol.isClass && recordTpe.typeSymbol.asClass.isCaseClass => {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -145,6 +145,14 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
   case object NoMatch extends TableMatchResult
 
+  def show(list: List[Type]): String = {
+    list map(tpe => showCode(tq"$tpe")) mkString ", "
+  }
+
+  def show(list: Iterable[Type]): String = {
+    list map(tpe => showCode(tq"$tpe")) mkString ", "
+  }
+
   /**
     * Finds a matching subset of columns inside a table definition where the extracted
     * type from a table does not need to include all of the columns inside a table.
@@ -162,11 +170,13 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
     if (members.isEmpty) {
       NoMatch
     } else {
-      if (members.size >= recordMembers.size && recordMembers.zip(members).forall { case (rec, col) =>
+      Console.println(s"Table column members ${show(members.map(_.tpe))}")
+      Console.println(s"Record members ${show(recordMembers.map(_.tpe))}")
+      if (members.size >= recordMembers.size && members.zip(recordMembers).forall { case (rec, col) =>
         rec.tpe =:= col.tpe
       }) {
         Match(members, recordMembers.size != members.size)
-      } else{
+      } else {
         findMatchingSubset(members.tail, recordMembers)
       }
     }
@@ -258,8 +268,7 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
         Some(q"""new $recordTpe(..$columnNames)""")
       }
-      case _ => None
-      case NoMatch => {
+      case _ => {
         Console.println(s"Couldn't automatically infer an extractor for $tableSymbolName")
         None
       }
@@ -318,7 +327,6 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
           }
        }
     """
-    println(showCode(tree))
     tree
   }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -16,8 +16,10 @@
 package com.outworkers.phantom.macros
 
 import com.datastax.driver.core.Row
+import com.outworkers.phantom.builder.query.InsertQuery
 import com.outworkers.phantom.{CassandraTable, SelectTable}
 import com.outworkers.phantom.column.AbstractColumn
+import com.outworkers.phantom.dsl.KeySpace
 import com.outworkers.phantom.keys.{ClusteringOrder, PartitionKey, PrimaryKey}
 
 import scala.reflect.macros.blackbox
@@ -31,6 +33,8 @@ trait TableHelper[T <: CassandraTable[T, R], R] {
   def tableKey(table: T): String
 
   def fields(table: CassandraTable[T, R]): Set[AbstractColumn[_]]
+
+  def store(table: CassandraTable[T, R])(implicit space: KeySpace): InsertQuery.Default[T, R]
 }
 
 object TableHelper {
@@ -42,20 +46,21 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
   import c.universe._
 
-  val rowType = tq"com.datastax.driver.core.Row"
-  val builder = q"com.outworkers.phantom.builder.QueryBuilder"
-  val strTpe = tq"java.lang.String"
-  val colType = tq"com.outworkers.phantom.column.AbstractColumn[_]"
-  val collections = q"scala.collection.immutable"
-  val rowTerm = TermName("row")
-  val tableTerm = TermName("table")
+  private[this] val rowType = tq"com.datastax.driver.core.Row"
+  private[this] val builder = q"com.outworkers.phantom.builder.QueryBuilder"
+  private[this] val strTpe = tq"java.lang.String"
+  private[this] val colType = tq"com.outworkers.phantom.column.AbstractColumn[_]"
+  private[this] val collections = q"scala.collection.immutable"
+  private[this] val rowTerm = TermName("row")
+  private[this] val tableTerm = TermName("table")
+  private[this] val keyspaceType = tq"com.outworkers.phantom.connectors.KeySpace"
 
   val knownList = List("Any", "Object", "RootConnector")
 
-  val tableSym = typeOf[CassandraTable[_, _]].typeSymbol
-  val selectTable = typeOf[SelectTable[_, _]].typeSymbol
-  val rootConn = typeOf[SelectTable[_, _]].typeSymbol
-  val colSymbol = typeOf[AbstractColumn[_]].typeSymbol
+  val tableSym: Symbol = typeOf[CassandraTable[_, _]].typeSymbol
+  val selectTable: Symbol = typeOf[SelectTable[_, _]].typeSymbol
+  val rootConn: Symbol = typeOf[SelectTable[_, _]].typeSymbol
+  val colSymbol: Symbol = typeOf[AbstractColumn[_]].typeSymbol
 
   val exclusions: Symbol => Option[Symbol] = s => {
     val sig = s.typeSignature.typeSymbol
@@ -69,6 +74,10 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
   def filterColumns[Filter : TypeTag](columns: Seq[Type]): Seq[Type] = {
     columns.filter(_.baseClasses.exists(typeOf[Filter].typeSymbol == ))
+  }
+
+  def insertQueryType(table: Type, record: Type): Tree = {
+    tq"com.outworkers.phantom.builder.query.InsertQuery.Default[$table, $record]"
   }
 
   /**
@@ -118,6 +127,35 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
   }
 
+  def extractColumnMembers(table: Type, columns: List[Symbol]): List[Type] = {
+    /**
+      * We filter for the members of the table type that
+      * directly subclass [[AbstractColumn[_]]. For every one of those methods, we
+      * are going to look at what type argument was passed by the specific column definition
+      * when extending [[AbstractColumn[_]] as this will tell us the Scala output type
+      * of the given column.
+      * We create a list of these types and if they match the case class types expected,
+      * it means we can auto-generate a fromRow implementation.
+      */
+    columns.map { member =>
+      val memberType = member.typeSignatureIn(table)
+
+      memberType.baseClasses.find(colSymbol ==) match {
+        case Some(root) =>
+          // Here we expect to have a single type argument or type param
+          // because we know root here will point to an AbstractColumn[_] symbol.
+          root.typeSignature.typeParams match {
+            // We use the special API to see what type was passed through to AbstractColumn[_]
+            // with special thanks to https://github.com/joroKr21 for helping me not rip
+            // the remainder of my hair off while uncovering this marvelous macro API method.
+            case head :: Nil => head.asType.toType.asSeenFrom(memberType, colSymbol)
+            case _ => c.abort(c.enclosingPosition, "Expected exactly one type parameter provided for root column type")
+          }
+        case None => c.abort(c.enclosingPosition, s"Could not find root column type for ${member.asModule.name}")
+      }
+    }
+  }
+
   /**
     * Materializes an extractor method for a table, the so called "fromRow" method.
     *
@@ -165,54 +203,20 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
       */
     val recordMembers = fields(recordTpe) map (_._2)
 
-    /**
-      * Then we do the same for the columns, we filter for the members of the table type that
-      * directly subclass [[AbstractColumn[_]]. For every one of those methods, we
-      * are going to look at what type argumnt was passed by the specific column definition
-      * when extending [[AbstractColumn[_]] as this will tell us the Scala output type
-      * of the given column.
-      * We create a list of these types and if they match the case class types expected,
-      * it means we can auto-generate a fromRow implementation.
-      */
-    val colMembers = columns.map { member =>
-      val memberType = member.typeSignatureIn(tableTpe)
-
-      memberType.baseClasses.find(colSymbol ==) match {
-        case Some(root) =>
-          // Here we expect to have a single type argument or type param
-          // because we know root here will point to an AbstractColumn[_] symbol.
-          root.typeSignature.typeParams match {
-            // We use the special API to see what type was passed through to AbstractColumn[_]
-            // with special thanks to https://github.com/joroKr21 for helping me not rip
-            // the remainder of my hair off while uncovering this marvelous macro API method.
-            case head :: Nil => head.asType.toType.asSeenFrom(memberType, colSymbol)
-            case _ => c.abort(c.enclosingPosition, "Expected exactly one type parameter provided for root column type")
-          }
-        case None => c.abort(c.enclosingPosition, s"Could not find root column type for ${member.asModule.name}")
-      }
-    }
+    val colMembers = extractColumnMembers(tableTpe, columns)
 
     val tableSymbolName = tableTpe.typeSymbol.name
-    Console.println(recordMembers.map(_.typeSymbol.name.toTypeName.decodedName.toString).mkString(", "))
-    Console.println(colMembers.map(_.typeSymbol.name.toTermName.decodedName.toString).mkString(", "))
-
     if (recordMembers.size == colMembers.size) {
       if (recordMembers.zip(colMembers).forall { case (rec, col) => {
-        val res = rec =:= col
-        Console.println(s"$rec was equal to $col status: $res" )
-        res
+        rec =:= col
       } }) {
         Some(q"""new $recordTpe(..$columnNames)""")
       } else {
         Console.println(s"The case class records did not match the column member types for $tableSymbolName")
-        Console.println(recordMembers.map(_.typeSymbol.name.toTypeName.decodedName.toString).mkString(", "))
-        Console.println(colMembers.map(_.typeSymbol.name.toTermName.decodedName.toString).mkString(", "))
         None
       }
     } else {
       Console.println(s"There were ${recordMembers.size} case class fields and ${colMembers.size} columns for ${tableSymbolName}")
-      Console.println(recordMembers.map(_.typeSymbol.name.toTypeName.decodedName.toString).mkString(", "))
-      Console.println(colMembers.map(_.typeSymbol.name.toTermName.decodedName.toString).mkString(", "))
       None
     }
   }
@@ -252,9 +256,13 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
 
     val accessors = columns.map(_.asTerm.name).map(tm => q"table.instance.${tm.toTermName}")
 
-    q"""
+    val tree = q"""
        new com.outworkers.phantom.macros.TableHelper[$tableType, $rTpe] {
           def tableName: $strTpe = $tableName
+
+          def store($tableTerm: $tableType)(implicit space: $keyspaceType): ${insertQueryType(tableType, rTpe)} = {
+            $tableTerm.insert()
+          }
 
           def tableKey($tableTerm: $tableType): $strTpe = ${inferPrimaryKey(tableName, tableType, referenceColumns.map(_.typeSignature))}
 
@@ -265,6 +273,8 @@ class TableHelperMacro(override val c: blackbox.Context) extends MacroUtils(c) {
           }
        }
     """
+    println(showCode(tree))
+    tree
   }
 
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/primitives/DerivedPrimitivesTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/primitives/DerivedPrimitivesTest.scala
@@ -22,7 +22,7 @@ import com.outworkers.util.testing._
 case class Record(value: String)
 
 object Record {
-  implicit val recordPrimitive = Primitive.derive[Record, String](_.value)(Record.apply)
+  implicit val recordPrimitive: Primitive[Record] = Primitive.derive[Record, String](_.value)(Record.apply)
 }
 
 class DerivedPrimitivesTest extends PhantomSuite {
@@ -30,6 +30,6 @@ class DerivedPrimitivesTest extends PhantomSuite {
   it should "derive a primitive for a custom wrapper type" in {
     val str = gen[String]
 
-    Primitive[Record].asCql(Record(str)) shouldEqual CQLQuery.escaped(str)
+    Primitive[Record].asCql(Record(str)) shouldEqual CQLQuery.escape(str)
   }
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/primitives/DerivedPrimitivesTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/primitives/DerivedPrimitivesTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 - 2017 Outworkers Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.outworkers.phantom.builder.primitives
+
+import com.outworkers.phantom.PhantomSuite
+import com.outworkers.phantom.builder.query.CQLQuery
+import com.outworkers.util.testing._
+
+case class Record(value: String)
+
+object Record {
+  implicit val recordPrimitive = Primitive.derive[Record, String](_.value)(Record.apply)
+}
+
+class DerivedPrimitivesTest extends PhantomSuite {
+
+  it should "derive a primitive for a custom wrapper type" in {
+    val str = gen[String]
+
+    Primitive[Record].asCql(Record(str)) shouldEqual CQLQuery.escaped(str)
+  }
+}

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
@@ -137,17 +137,6 @@ class TableHelperTest extends PhantomSuite with MockFactory {
 
     val instance = Ev2(gen[UUID], genList[String]().toSet)
 
-    val primitive = Primitive[String]
-
-    (row.getUUID(_: String))
-      .when("id")
-      .returns(instance.id)
-
-    (row.getSet[String](_: String, _: primitive.PrimitiveType))
-      .when("set", Primitive[String].clz)
-      .returns(instance.set.asJava)
-
-
     val ev = new Events2()
 
     intercept[NullPointerException] {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
@@ -114,4 +114,22 @@ class TableHelperTest extends PhantomSuite {
       ev.fromRow(null.asInstanceOf[Row])
     }
   }
+
+  it should "generate a fromRow method from a partial table definition" in {
+    case class Ev2(
+      id: UUID,
+      set: Set[Int]
+    )
+
+    class Events2 extends CassandraTable[Events2, Ev2] {
+      object partition extends UUIDColumn(this) with PartitionKey
+      object id extends UUIDColumn(this) with PartitionKey
+      object map extends SetColumn[String](this)
+    }
+
+    val ev = new Events2()
+    intercept[NullPointerException] {
+      ev.fromRow(null.asInstanceOf[Row])
+    }
+  }
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
@@ -149,8 +149,9 @@ class TableHelperTest extends PhantomSuite with MockFactory {
 
 
     val ev = new Events2()
-    val res = ev.fromRow(row)
 
-    res shouldEqual instance
+    intercept[NullPointerException] {
+      ev.fromRow(row)
+    }
   }
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/macros/TableHelperTest.scala
@@ -18,8 +18,9 @@ package com.outworkers.phantom.macros
 import com.outworkers.phantom.PhantomSuite
 import org.joda.time.DateTime
 import com.outworkers.phantom.dsl._
+import org.scalamock.scalatest.MockFactory
 
-class TableHelperTest extends PhantomSuite {
+class TableHelperTest extends PhantomSuite with MockFactory {
 
   it should "not generate a fromRow if a normal type is different" in {
 
@@ -116,9 +117,12 @@ class TableHelperTest extends PhantomSuite {
   }
 
   it should "generate a fromRow method from a partial table definition" in {
+
+    val row = mock[Row]
+
     case class Ev2(
       id: UUID,
-      set: Set[Int]
+      set: Set[String]
     )
 
     class Events2 extends CassandraTable[Events2, Ev2] {
@@ -128,8 +132,6 @@ class TableHelperTest extends PhantomSuite {
     }
 
     val ev = new Events2()
-    intercept[NullPointerException] {
-      ev.fromRow(null.asInstanceOf[Row])
-    }
+    val res = ev.fromRow(row)
   }
 }

--- a/phantom-finagle/src/test/scala/com/outworkers/phantom/finagle/SpoolBenchmarkPerformanceTest.scala
+++ b/phantom-finagle/src/test/scala/com/outworkers/phantom/finagle/SpoolBenchmarkPerformanceTest.scala
@@ -21,13 +21,15 @@ import com.outworkers.phantom.tables.{JodaRow, TestDatabase}
 import com.outworkers.util.testing._
 import org.scalameter.api.{Gen => MeterGen, gen => _, _}
 import org.scalatest.time.SpanSugar._
+
+import scala.collection.immutable.IndexedSeq
 import scala.concurrent.{Await, Future}
 
-class SpoolBenchmarkPerformanceTest extends PerformanceTest.Quickbenchmark with TestDatabase.connector.Connector {
+class SpoolBenchmarkPerformanceTest extends Bench.LocalTime with TestDatabase.connector.Connector {
 
   TestDatabase.primitivesJoda.insertSchema()
 
-  val fs = for {
+  val fs: IndexedSeq[Future[Unit]] = for {
     step <- 1 to 3
     rows = Iterator.fill(10000)(gen[JodaRow])
 
@@ -39,7 +41,7 @@ class SpoolBenchmarkPerformanceTest extends PerformanceTest.Quickbenchmark with 
       b.add(statement)
     })
     w = batch.future()
-    f = w map (_ => println(s"step $step has succeed") )
+    f = w map (_ =>println(s"step $step has succeed") )
     r = Await.result(f, 200 seconds)
   } yield f map (_ => r)
 
@@ -51,7 +53,7 @@ class SpoolBenchmarkPerformanceTest extends PerformanceTest.Quickbenchmark with 
     measure method "fetchSpool" in {
       using(sizes) in {
         size => TwitterAwait.ready {
-          TestDatabase.primitivesJoda.select.limit(size).fetchSpool().flatMap(s => s.toSeq)
+          TestDatabase.primitivesJoda.select.limit(size).fetchSpool().flatMap(_.toSeq)
         }
       }
     }

--- a/phantom-streams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/iteratee/IterateeBenchmarkPerformanceTest.scala
+++ b/phantom-streams/src/test/scala/com/outworkers/phantom/reactivestreams/suites/iteratee/IterateeBenchmarkPerformanceTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.time.SpanSugar._
 
 import scala.concurrent.{Await, Future}
 
-class IterateeBenchmarkPerformanceTest extends PerformanceTest.Quickbenchmark with TestDatabase.connector.Connector {
+class IterateeBenchmarkPerformanceTest extends Bench.LocalTime with TestDatabase.connector.Connector {
 
   TestDatabase.primitivesJoda.insertSchema()
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,7 +27,6 @@ def outworkersPattern: Patterns = {
 
 resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven",
-  "Artima Maven Repository" at "http://repo.artima.com/releases",
   "Twitter Repo" at "http://maven.twttr.com/",
   Resolver.sonatypeRepo("releases"),
   Resolver.bintrayRepo("websudos", "oss-releases"),
@@ -61,5 +60,3 @@ addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.7.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
-
-addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,9 +26,10 @@ def outworkersPattern: Patterns = {
 }
 
 resolvers ++= Seq(
-  Resolver.sonatypeRepo("releases"),
   "jgit-repo" at "http://download.eclipse.org/jgit/maven",
+  "Artima Maven Repository" at "http://repo.artima.com/releases",
   "Twitter Repo" at "http://maven.twttr.com/",
+  Resolver.sonatypeRepo("releases"),
   Resolver.bintrayRepo("websudos", "oss-releases"),
   Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns),
   Resolver.url("bintray-csl-sbt-plugins", url("https://dl.bintray.com/twittercsl/sbt-plugins"))(Resolver.mavenStylePatterns),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -61,3 +61,5 @@ addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.7.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+
+addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.0")


### PR DESCRIPTION
- Adding ability to derive primitives based on a source type.
- Adding ability to skip bumping versions during CI cycles based on the latest GitHub commit message.
- Adding the ability to automatically generate a `store` method for a table which allows users to insert records into a table without manually creating the value matched part of an insert query. The macro automatically expands `insert.value(_.name, rec.name)...` and so on, wherever possible.