### PR TITLE
Feature/prepare async

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CassandraOperations.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CassandraOperations.scala
@@ -40,6 +40,25 @@ private[phantom] trait CassandraOperations extends SessionAugmenterImplicits {
     statementToPromise(batch.statement)
   }
 
+  def guavaToScala[T](source: ListenableFuture[T])(
+    implicit executor: ExecutionContextExecutor
+  ): ScalaPromise[T] = {
+    val promise = ScalaPromise[T]()
+
+    val callback = new FutureCallback[T] {
+      def onSuccess(result: T): Unit = {
+        promise success result
+      }
+
+      def onFailure(err: Throwable): Unit = {
+        promise failure err
+      }
+    }
+
+    Futures.addCallback(source, callback, executor)
+    promise
+  }
+
   protected[this] def statementToPromise(st: Statement)(
     implicit session: Session,
     executor: ExecutionContextExecutor

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
@@ -16,17 +16,19 @@
 package com.outworkers.phantom.builder.query
 
 import com.datastax.driver.core.{ConsistencyLevel, Session}
-import com.outworkers.phantom.{ CassandraTable, Row }
+import com.outworkers.phantom.{CassandraTable, Row}
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.clauses._
 import com.outworkers.phantom.builder.ops.MapKeyUpdateClause
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.prepared.PreparedBlock
+import com.outworkers.phantom.builder.query.prepared.{PreparedBlock, PreparedFlattener, PreparedSelectBlock}
 import com.outworkers.phantom.column.AbstractColumn
 import com.outworkers.phantom.connectors.KeySpace
 import com.outworkers.phantom.dsl.DateTime
 import shapeless.ops.hlist.{Prepend, Reverse}
 import shapeless.{=:!=, HList, HNil}
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 class DeleteQuery[
   Table <: CassandraTable[Table, _],
@@ -78,7 +80,22 @@ class DeleteQuery[
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev]
   ): PreparedBlock[Rev] = {
-    new PreparedBlock(qb, options)
+    val flatten = new PreparedFlattener(qb)
+    new PreparedBlock(flatten.query, flatten.protocolVersion, options)
+  }
+
+  def prepareAsync[Rev <: HList]()(
+    implicit session: Session,
+    executor: ExecutionContextExecutor,
+    keySpace: KeySpace,
+    ev: PS =:!= HNil,
+    rev: Reverse.Aux[PS, Rev]
+  ): Future[PreparedBlock[Rev]] = {
+    val flatten = new PreparedFlattener(qb)
+
+    flatten.async map { ps =>
+      new PreparedBlock(ps, flatten.protocolVersion, options)
+    }
   }
 
   def timestamp(time: Long): DeleteQuery[Table, Record, Limit, Order, Status, Chainned, PS] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
@@ -263,20 +263,6 @@ sealed case class AssignmentsQuery[
     }
   }
 
-  def prepareAsync[Rev <: HList]()(
-    implicit session: Session,
-    executor: ExecutionContextExecutor,
-    keySpace: KeySpace,
-    ev: PS =:!= HNil,
-    rev: Reverse.Aux[PS, Rev]
-  ): Future[PreparedBlock[Rev]] = {
-    val flatten = new PreparedFlattener(qb)
-
-    flatten.async map { ps =>
-      new PreparedBlock[Rev](ps, flatten.protocolVersion, options)
-    }
-  }
-
   /**
    * Generates a conditional query clause based on CQL lightweight transactions.
    * Compare and set transactions only get executed if a particular condition is true.

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
@@ -16,19 +16,20 @@
 package com.outworkers.phantom.builder.query
 
 import com.datastax.driver.core.{ConsistencyLevel, Session}
-import com.outworkers.phantom.{ CassandraTable, Row }
+import com.outworkers.phantom.{CassandraTable, Row}
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.clauses._
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.prepared.{PrepareMark, PreparedBlock}
+import com.outworkers.phantom.builder.query.prepared.{PrepareMark, PreparedBlock, PreparedFlattener}
 import com.outworkers.phantom.connectors.KeySpace
 import com.outworkers.phantom.dsl.DateTime
 import shapeless.ops.hlist.{Prepend, Reverse}
 import shapeless.{::, =:!=, HList, HNil}
 
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
 
-class UpdateQuery[
+case class UpdateQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Limit <: LimitBound,
@@ -57,8 +58,28 @@ class UpdateQuery[
     P <: HList
   ] = UpdateQuery[T, R, L, O, S, C, P]
 
-  def prepare()(implicit session: Session, keySpace: KeySpace, ev: PS =:!= HNil): PreparedBlock[PS] = {
-    new PreparedBlock[PS](qb, options)
+  def prepare[Rev <: HList]()(
+    implicit session: Session,
+    keySpace: KeySpace,
+    ev: PS =:!= HNil,
+    rev: Reverse.Aux[PS, Rev]
+  ): PreparedBlock[Rev] = {
+    val flatten = new PreparedFlattener(qb)
+    new PreparedBlock(flatten.query, flatten.protocolVersion, options)
+  }
+
+  def prepareAsync[Rev <: HList]()(
+    implicit session: Session,
+    executor: ExecutionContextExecutor,
+    keySpace: KeySpace,
+    ev: PS =:!= HNil,
+    rev: Reverse.Aux[PS, Rev]
+  ): Future[PreparedBlock[Rev]] = {
+    val flatten = new PreparedFlattener(qb)
+
+    flatten.async map { ps =>
+      new PreparedBlock(ps, flatten.protocolVersion, options)
+    }
   }
 
   protected[this] def create[
@@ -82,14 +103,7 @@ class UpdateQuery[
   }
 
   override def ttl(seconds: Long): UpdateQuery[Table, Record, Limit, Order, Status, Chain, PS] = {
-    new UpdateQuery(
-      table,
-      init, usingPart,
-      wherePart,
-      setPart append QueryBuilder.ttl(seconds.toString),
-      casPart,
-      options
-    )
+    copy(setPart = setPart append QueryBuilder.ttl(seconds.toString))
   }
 
   /**
@@ -106,15 +120,7 @@ class UpdateQuery[
     ev: Chain =:= Unchainned,
     prepend: Prepend.Aux[HL, PS, Out]
   ): QueryType[Table, Record, Limit, Order, Status, Chainned, Out] = {
-    new UpdateQuery(
-      table,
-      init,
-      usingPart,
-      wherePart append QueryBuilder.Update.where(condition(table).qb),
-      setPart,
-      casPart,
-      options
-    )
+    copy(wherePart = wherePart append QueryBuilder.Update.where(condition(table).qb))
   }
 
   /**
@@ -131,15 +137,7 @@ class UpdateQuery[
     ev: Chain =:= Chainned,
     prepend: Prepend.Aux[HL, PS, Out]
   ): QueryType[Table, Record, Limit, Order, Status, Chainned, Out] = {
-    new UpdateQuery(
-      table,
-      init,
-      usingPart,
-      wherePart append QueryBuilder.Update.and(condition(table).qb),
-      setPart,
-      casPart,
-      options
-    )
+    copy(wherePart = wherePart append QueryBuilder.Update.and(condition(table).qb))
   }
 
   final def modify[
@@ -148,6 +146,7 @@ class UpdateQuery[
   ](clause: Table => UpdateClause.Condition[HL])(
     implicit prepend: Prepend.Aux[HL, HNil, Out]
   ): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, Out] = {
+
     new AssignmentsQuery(
       table = table,
       init = init,
@@ -167,7 +166,7 @@ class UpdateQuery[
    * @return A conditional query, now bound by a compare-and-set part.
    */
   def onlyIf(clause: Table => CompareAndSetClause.Condition): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, HNil] = {
-    new ConditionalQuery(
+    ConditionalQuery(
       table,
       init,
       usingPart,
@@ -179,7 +178,7 @@ class UpdateQuery[
   }
 }
 
-sealed class AssignmentsQuery[
+sealed case class AssignmentsQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Limit <: LimitBound,
@@ -189,7 +188,7 @@ sealed class AssignmentsQuery[
   PS <: HList,
   ModifyPrepared <: HList
 ](table: Table,
-  val init: CQLQuery,
+  init: CQLQuery,
   usingPart: UsingPart = UsingPart.empty,
   wherePart : WherePart = WherePart.empty,
   private[phantom] val setPart : SetPart = SetPart.empty,
@@ -205,82 +204,51 @@ sealed class AssignmentsQuery[
   ](clause: Table => UpdateClause.Condition[HL])(
     implicit prepend: Prepend.Aux[HL, ModifyPrepared, Out]
   ): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, Out] = {
-    new AssignmentsQuery(
-      table = table,
-      init = init,
-      usingPart = usingPart,
-      wherePart = wherePart,
-      setPart appendConditionally (clause(table).qb, !clause(table).skipped),
-      casPart = casPart,
-      options = options
-    )
+    copy(setPart = setPart appendConditionally (clause(table).qb, !clause(table).skipped))
   }
 
   final def timestamp(value: Long): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new AssignmentsQuery(
-      table = table,
-      init = init,
-      usingPart = usingPart append QueryBuilder.timestamp(value),
-      wherePart = wherePart,
-      setPart = setPart,
-      casPart = casPart,
-      options = options
-    )
+    copy(usingPart = usingPart append QueryBuilder.timestamp(value))
   }
 
   final def timestamp(value: DateTime): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new AssignmentsQuery(
-      table = table,
-      init = init,
-      usingPart = usingPart append QueryBuilder.timestamp(value.getMillis),
-      wherePart = wherePart,
-      setPart = setPart,
-      casPart = casPart,
-      options = options
-    )
+    copy(usingPart = usingPart append QueryBuilder.timestamp(value.getMillis))
   }
 
   final def ttl(mark: PrepareMark): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, Long :: PS, ModifyPrepared] = {
-    new AssignmentsQuery(
-      table = table,
-      init = init,
-      usingPart = usingPart append QueryBuilder.ttl(mark.qb.queryString),
-      wherePart = wherePart,
-      setPart = setPart,
-      casPart = casPart,
-      options = options
-    )
+    copy(usingPart = usingPart append QueryBuilder.ttl(mark.qb.queryString))
   }
 
   final def ttl(seconds: Long): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new AssignmentsQuery(
-      table = table,
-      init = init,
-      usingPart = usingPart append QueryBuilder.ttl(seconds.toString),
-      wherePart = wherePart,
-      setPart = setPart,
-      casPart = casPart,
-      options = options
-    )
+    copy(usingPart = usingPart append QueryBuilder.ttl(seconds.toString))
   }
 
   final def ttl(duration: ScalaDuration): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
     ttl(duration.toSeconds)
   }
 
-  def prepare[
-    Rev <: HList,
-    Reversed <: HList,
-    Out <: HList
-  ]()(
+  def prepare[Rev <: HList]()(
     implicit session: Session,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
-    rev: Reverse.Aux[PS, Rev],
-    rev2: Reverse.Aux[ModifyPrepared, Reversed],
-    prepend: Prepend.Aux[Reversed, Rev, Out]
-  ): PreparedBlock[Out] = {
-    new PreparedBlock(qb, options)
+    rev: Reverse.Aux[PS, Rev]
+  ): PreparedBlock[Rev] = {
+    val flatten = new PreparedFlattener(qb)
+    new PreparedBlock(flatten.query, flatten.protocolVersion, options)
+  }
+
+  def prepareAsync[Rev <: HList]()(
+    implicit session: Session,
+    executor: ExecutionContextExecutor,
+    keySpace: KeySpace,
+    ev: PS =:!= HNil,
+    rev: Reverse.Aux[PS, Rev]
+  ): Future[PreparedBlock[Rev]] = {
+    val flatten = new PreparedFlattener(qb)
+
+    flatten.async map { ps =>
+      new PreparedBlock(ps, flatten.protocolVersion, options)
+    }
   }
 
   /**
@@ -291,7 +259,7 @@ sealed class AssignmentsQuery[
    * @return A conditional query, now bound by a compare-and-set part.
    */
   def onlyIf(clause: Table => CompareAndSetClause.Condition): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new ConditionalQuery(
+    ConditionalQuery(
       table,
       init,
       usingPart,
@@ -303,7 +271,7 @@ sealed class AssignmentsQuery[
   }
 
   def ifExists: ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new ConditionalQuery(
+    ConditionalQuery(
       table,
       init,
       usingPart,
@@ -319,31 +287,14 @@ sealed class AssignmentsQuery[
     session: Session
   ): AssignmentsQuery[Table, Record, Limit, Order, Specified, Chain, PS, ModifyPrepared] = {
     if (session.protocolConsistency) {
-      new AssignmentsQuery(
-        table,
-        init,
-        usingPart,
-        wherePart,
-        setPart,
-        casPart,
-        options.consistencyLevel_=(level)
-      )
+      copy(options = options.consistencyLevel_=(level))
     } else {
-      new AssignmentsQuery(
-        table,
-        init,
-        usingPart append QueryBuilder.consistencyLevel(level.toString),
-        wherePart,
-        setPart,
-        casPart,
-        options
-      )
+      copy(usingPart = usingPart append QueryBuilder.consistencyLevel(level.toString))
     }
-
   }
 }
 
-sealed class ConditionalQuery[
+sealed case class ConditionalQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Limit <: LimitBound,
@@ -368,67 +319,50 @@ sealed class ConditionalQuery[
   final def and(
     clause: Table => CompareAndSetClause.Condition
   ): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new ConditionalQuery(
-      table,
-      init,
-      usingPart,
-      wherePart,
-      setPart,
-      casPart append QueryBuilder.Update.and(clause(table).qb),
-      options
-    )
+    copy(casPart = casPart append QueryBuilder.Update.and(clause(table).qb))
   }
 
   def consistencyLevel_=(level: ConsistencyLevel)(
     implicit ev: Status =:= Unspecified, session: Session
   ): ConditionalQuery[Table, Record, Limit, Order, Specified, Chain, PS, ModifyPrepared] = {
     if (session.protocolConsistency) {
-      new ConditionalQuery(
-        table = table,
-        init = init,
-        usingPart = usingPart,
-        wherePart = wherePart,
-        setPart = setPart,
-        casPart = casPart,
-        options.consistencyLevel_=(level)
-      )
+      copy(options = options.consistencyLevel_=(level))
     } else {
-      new ConditionalQuery(
-        table = table,
-        init = init,
-        usingPart = usingPart append QueryBuilder.consistencyLevel(level.toString),
-        wherePart = wherePart,
-        setPart = setPart,
-        casPart = casPart,
-        options = options
-      )
+      copy(usingPart = usingPart append QueryBuilder.consistencyLevel(level.toString))
     }
   }
 
   def ttl(seconds: Long): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
-    new ConditionalQuery(
-      table,
-      init,
-      usingPart,
-      wherePart,
-      setPart append QueryBuilder.ttl(seconds.toString),
-      casPart,
-      options
-    )
+    copy(setPart = setPart append QueryBuilder.ttl(seconds.toString))
   }
 
   final def ttl(duration: ScalaDuration): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifyPrepared] = {
     ttl(duration.toSeconds)
   }
 
-  def prepare[Rev <: HList, Rev2 <: HList, Out <: HList]()(
+  def prepare[Rev <: HList]()(
     implicit session: Session,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
-    rev: Reverse.Aux[PS, Rev],
-    rev2: Reverse.Aux[ModifyPrepared, Rev2],
-    prepend: Prepend.Aux[Rev2, Rev, Out]
-  ): PreparedBlock[Out] = new PreparedBlock(qb, options)
+    rev: Reverse.Aux[PS, Rev]
+  ): PreparedBlock[Rev] = {
+    val flatten = new PreparedFlattener(qb)
+    new PreparedBlock(flatten.query, flatten.protocolVersion, options)
+  }
+
+  def prepareAsync[Rev <: HList]()(
+    implicit session: Session,
+    executor: ExecutionContextExecutor,
+    keySpace: KeySpace,
+    ev: PS =:!= HNil,
+    rev: Reverse.Aux[PS, Rev]
+  ): Future[PreparedBlock[Rev]] = {
+    val flatten = new PreparedFlattener(qb)
+
+    flatten.async map { ps =>
+      new PreparedBlock(ps, flatten.protocolVersion, options)
+    }
+  }
 }
 
 object UpdateQuery {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromise.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromise.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 - 2017 Outworkers Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.outworkers.phantom.builder.query.prepared
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.{Future, Promise}
+
+class ExactlyOncePromise[T](f: => Promise[T]) {
+  private[this] val promise = Promise[T]()
+
+  def future: Future[T] = promise.future
+
+  private[this] val flag = new AtomicBoolean(false)
+
+  def init: Future[T] = {
+    if (!flag.getAndSet(true)) {
+      promise.tryCompleteWith(f.future)
+    }
+    future
+  }
+}
+
+object ExactlyOncePromise {
+  def apply[T](f: => Promise[T]): ExactlyOncePromise[T] = new ExactlyOncePromise[T](f)
+}
+
+

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -75,17 +75,27 @@ class ExecutablePreparedSelectQuery[
   override def qb: CQLQuery = CQLQuery.empty
 }
 
-abstract class PreparedFlattener(qb: CQLQuery)(
-  implicit session: Session, keySpace: KeySpace
-) extends SessionAugmenterImplicits {
+class PreparedFlattener(qb: CQLQuery)(
+  implicit session: Session,
+  keySpace: KeySpace
+) extends SessionAugmenterImplicits with CassandraOperations {
 
-  protected[this] val query: PreparedStatement = {
+  val protocolVersion: ProtocolVersion = session.protocolVersion
+
+  def query: PreparedStatement = {
     blocking(session.prepare(qb.queryString))
+  }
+
+  def async()(implicit executor: ExecutionContextExecutor): ScalaFuture[PreparedStatement] = {
+    ExactlyOncePromise(guavaToScala(session.prepareAsync(qb.queryString))).future
   }
 }
 
-class PreparedBlock[PS <: HList](val qb: CQLQuery, val options: QueryOptions)
-  (implicit session: Session, keySpace: KeySpace) extends PreparedFlattener(qb) {
+class PreparedBlock[PS <: HList](
+  query: PreparedStatement,
+  protocolVersion: ProtocolVersion,
+  val options: QueryOptions
+)(implicit session: Session, keySpace: KeySpace) {
 
   /**
     * Method used to bind a set of arguments to a prepared query in a typesafe manner.
@@ -105,7 +115,7 @@ class PreparedBlock[PS <: HList](val qb: CQLQuery, val options: QueryOptions)
     val bb = binder.bind(
       query,
       v1,
-      session.protocolVersion
+      protocolVersion
     )
 
     new ExecutablePreparedQuery(bb, options)
@@ -123,7 +133,7 @@ class PreparedBlock[PS <: HList](val qb: CQLQuery, val options: QueryOptions)
     binder: BindHelper[V]
   ): ExecutablePreparedQuery = {
     new ExecutablePreparedQuery(
-      binder.bind(query, v, session.protocolVersion),
+      binder.bind(query, v, protocolVersion),
       options
     )
   }
@@ -134,8 +144,12 @@ class PreparedSelectBlock[
   R,
   Limit <: LimitBound,
   PS <: HList
-  ](qb: CQLQuery, fn: Row => R, options: QueryOptions)
-(implicit session: Session, keySpace: KeySpace) extends PreparedFlattener(qb) {
+](
+  query: PreparedStatement,
+  protocolVersion: ProtocolVersion,
+  fn: Row => R,
+  options: QueryOptions
+)(implicit session: Session, keySpace: KeySpace) {
 
   /**
     * Method used to bind a set of arguments to a prepared query in a typesafe manner.
@@ -155,7 +169,7 @@ class PreparedSelectBlock[
     val bb = binder.bind(
       query,
       v1,
-      session.protocolVersion
+      protocolVersion
     )
 
     new ExecutablePreparedSelectQuery(bb, fn, options)
@@ -173,7 +187,7 @@ class PreparedSelectBlock[
     binder: BindHelper[V]
   ): ExecutablePreparedSelectQuery[T, R, Limit] = {
     new ExecutablePreparedSelectQuery(
-      binder.bind(query, v, session.protocolVersion),
+      binder.bind(query, v, protocolVersion),
       fn,
       options
     )

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -87,7 +87,7 @@ class PreparedFlattener(qb: CQLQuery)(
   }
 
   def async()(implicit executor: ExecutionContextExecutor): ScalaFuture[PreparedStatement] = {
-    ExactlyOncePromise(guavaToScala(session.prepareAsync(qb.queryString))).future
+    ExactlyOncePromise(guavaToScala(session.prepareAsync(qb.queryString)).future).future
   }
 }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 - 2017 Outworkers Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.outworkers.phantom.builder.query.prepared
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ExactlyOncePromiseTests extends FlatSpec with Matchers with ScalaFutures {
+
+  it should "only execute the logic inside an exactly once promise a single time" in {
+    val atomic = new AtomicInteger(0)
+
+    val promise = ExactlyOncePromise(Future(atomic.incrementAndGet()))
+
+    val chain = for {
+      one <- promise.future
+      two <- promise.future
+      three <- promise.future
+      four <- promise.future
+    } yield four
+
+    whenReady(chain) { res =>
+      res shouldEqual 1
+    }
+  }
+
+}

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedDeleteQueryTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedDeleteQueryTest.scala
@@ -30,12 +30,30 @@ class PreparedDeleteQueryTest extends PhantomSuite {
     database.articlesByAuthor.createSchema()
   }
 
-  it should "correctly execute a prepared delete query" in {
+  it should "execute a prepared delete query" in {
     val recipe = gen[Recipe]
 
     val query = database.recipes.delete.where(_.url eqs ?).prepare()
 
     val chain = for {
+      store <- database.recipes.store(recipe).future()
+      get <- database.recipes.select.where(_.url eqs recipe.url).one()
+      delete <- query.bind(recipe.url).future()
+      get2 <- database.recipes.select.where(_.url eqs recipe.url).one()
+    } yield (get, get2)
+
+    whenReady(chain) { case (initial, afterDelete) =>
+      initial shouldBe defined
+      initial.value shouldEqual recipe
+      afterDelete shouldBe empty
+    }
+  }
+
+  it should "execute an asynchronous prepared delete query" in {
+    val recipe = gen[Recipe]
+
+    val chain = for {
+      query <- database.recipes.delete.where(_.url eqs ?).prepareAsync()
       store <- database.recipes.store(recipe).future()
       get <- database.recipes.select.where(_.url eqs recipe.url).one()
       delete <- query.bind(recipe.url).future()
@@ -58,6 +76,24 @@ class PreparedDeleteQueryTest extends PhantomSuite {
       .prepare()
 
     val chain = for {
+      store <- database.articlesByAuthor.store(author, cat, article).future()
+      get <- database.articlesByAuthor.select.where(_.category eqs cat).and(_.author_id eqs author).one()
+      delete <- query.bind(cat, author).future()
+      get2 <- database.articlesByAuthor.select.where(_.category eqs cat).and(_.author_id eqs author).one()
+    } yield (get, get2)
+
+    whenReady(chain) { case (initial, afterDelete) =>
+      initial shouldBe defined
+      initial.value shouldEqual article
+      afterDelete shouldBe empty
+    }
+  }
+
+  it should "correctly execute an asynchronous prepared delete query with 2 bound values" in {
+    val (author, cat, article) = gen[(UUID, UUID, Article)]
+
+    val chain = for {
+      query <- database.articlesByAuthor.delete.where(_.category eqs ?).and(_.author_id eqs ?).prepareAsync()
       store <- database.articlesByAuthor.store(author, cat, article).future()
       get <- database.articlesByAuthor.select.where(_.category eqs cat).and(_.author_id eqs author).one()
       delete <- query.bind(cat, author).future()

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedInsertQueryTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedInsertQueryTest.scala
@@ -18,7 +18,7 @@ package com.outworkers.phantom.builder.query.prepared
 import com.datastax.driver.core.{BoundStatement, ProtocolVersion}
 import com.outworkers.phantom.PhantomSuite
 import com.outworkers.phantom.builder.primitives.{DerivedField, DerivedTupleField}
-import com.outworkers.phantom.dsl._
+import com.outworkers.phantom.dsl.{?, _}
 import com.outworkers.phantom.tables.{DerivedRecord, PrimitiveCassandra22, PrimitiveRecord, Recipe}
 import com.outworkers.util.samplers._
 
@@ -35,32 +35,44 @@ class PreparedInsertQueryTest extends PhantomSuite {
     }
   }
 
-  it should "serialize an insert query" in {
-
+  it should "execute a prepared insert query" in {
     val sample = gen[Recipe]
 
     val query = database.recipes.insert
-      .p_value(_.uid, ?)
       .p_value(_.url, ?)
-      .p_value(_.servings, ?)
-      .p_value(_.ingredients, ?)
       .p_value(_.description, ?)
+      .p_value(_.ingredients, ?)
+      .p_value(_.servings, ?)
       .p_value(_.lastcheckedat, ?)
       .p_value(_.props, ?)
+      .p_value(_.uid, ?)
       .prepare()
 
-    val exec = query.bind(
-      sample.uid,
-      sample.url,
-      sample.servings,
-      sample.ingredients,
-      sample.description,
-      sample.lastCheckedAt,
-      sample.props
-    ).future()
+    val chain = for {
+      store <- query.bind(sample).future()
+      get <- database.recipes.select.where(_.url eqs sample.url).one()
+    } yield get
+
+    whenReady(chain) { res =>
+      res shouldBe defined
+      res.value shouldEqual sample
+    }
+  }
+
+  it should "execute an asynchronous prepared insert query" in {
+    val sample = gen[Recipe]
 
     val chain = for {
-      store <- exec
+      query <- database.recipes.insert
+        .p_value(_.url, ?)
+        .p_value(_.description, ?)
+        .p_value(_.ingredients, ?)
+        .p_value(_.servings, ?)
+        .p_value(_.lastcheckedat, ?)
+        .p_value(_.props, ?)
+        .p_value(_.uid, ?)
+        .prepareAsync()
+      store <- query.bind(sample).future()
       get <- database.recipes.select.where(_.url eqs sample.url).one()
     } yield get
 
@@ -87,22 +99,8 @@ class PreparedInsertQueryTest extends PhantomSuite {
       .p_value(_.bi, ?)
       .prepare()
 
-    val exec = query.bind(
-      sample.pkey,
-      sample.long,
-      sample.boolean,
-      sample.bDecimal,
-      sample.double,
-      sample.float,
-      sample.inet,
-      sample.int,
-      sample.date,
-      sample.uuid,
-      sample.bi
-    ).future()
-
     val chain = for {
-      store <- exec
+      store <- query.bind(sample).future()
       get <- database.primitives.select.where(_.pkey eqs sample.pkey).one()
     } yield get
 
@@ -123,14 +121,12 @@ class PreparedInsertQueryTest extends PhantomSuite {
         .p_value(_.date, ?)
         .prepare()
 
-      val exec = query.bind(sample).future()
-
       val selectQuery = database.primitivesCassandra22.select
         .where(_.pkey eqs ?)
         .prepare()
 
       val chain = for {
-        store <- exec
+        store <- query.bind(sample).future()
         res <- selectQuery.bind(sample.pkey).one()
       } yield res
 
@@ -205,6 +201,30 @@ class PreparedInsertQueryTest extends PhantomSuite {
     }
   }
 
+  it should "be able to asynchronously bind a derived primitive" in {
+    val sample = DerivedRecord(
+      gen[UUID],
+      gen[ShortString].value,
+      gen[DerivedField],
+      gen[DerivedTupleField]
+    )
+
+    val chain = for {
+      query <- database.derivedPrimitivesTable.insert.p_value(_.id, ?)
+        .p_value(_.description, ?)
+        .p_value(_.rec, ?)
+        .p_value(_.complex, ?)
+        .prepareAsync()
+      store <- query.bind(sample).future()
+      res <- database.derivedPrimitivesTable.select.where(_.id eqs sample.id).one()
+    } yield res
+
+    whenReady(chain) { res =>
+      res shouldBe defined
+      res.value shouldEqual sample
+    }
+  }
+
   it should "be able to bind a custom Scala BigDecimal" in {
     val sample = gen[PrimitiveRecord]
 
@@ -224,6 +244,33 @@ class PreparedInsertQueryTest extends PhantomSuite {
 
     val chain = for {
       store <- query.bind(sample).future()
+      res <- database.primitives.select.where(_.pkey eqs sample.pkey).one()
+    } yield res
+
+    whenReady(chain) { res =>
+      res shouldBe defined
+      res.value shouldEqual sample
+    }
+  }
+
+  it should "be able to asynchronously bind a custom Scala BigDecimal" in {
+    val sample = gen[PrimitiveRecord]
+
+    val chain = for {
+      query <- database.primitives.insert
+        .p_value(_.pkey, ?)
+        .p_value(_.long, ?)
+        .p_value(_.boolean, ?)
+        .p_value(_.bDecimal, ?)
+        .p_value(_.double, ?)
+        .p_value(_.float, ?)
+        .p_value(_.inet, ?)
+        .p_value(_.int, ?)
+        .p_value(_.date, ?)
+        .p_value(_.uuid, ?)
+        .p_value(_.bi, ?)
+        .prepareAsync()
+       store <- query.bind(sample).future()
       res <- database.primitives.select.where(_.pkey eqs sample.pkey).one()
     } yield res
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedSelectQueryTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedSelectQueryTest.scala
@@ -16,7 +16,7 @@
 package com.outworkers.phantom.builder.query.prepared
 
 import com.outworkers.phantom.PhantomSuite
-import com.outworkers.phantom.dsl._
+import com.outworkers.phantom.dsl.{?, _}
 import com.outworkers.phantom.tables._
 import com.outworkers.util.samplers._
 
@@ -55,6 +55,26 @@ class PreparedSelectQueryTest extends PhantomSuite {
     }
   }
 
+  it should "serialise and execute an async prepared select with the same clause as a normal one" in {
+    val recipe = gen[Recipe]
+
+    val operation = for {
+      query <- database.recipes.select.where(_.url eqs ?).prepareAsync()
+      _ <- database.recipes.truncate.future
+      _ <- database.recipes.store(recipe).future()
+      select <- query.bind(recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
+    } yield (select, select2)
+
+    whenReady(operation) { case (items, items2) =>
+      items shouldBe defined
+      items.value shouldEqual recipe
+
+      items2 shouldBe defined
+      items2.value shouldEqual recipe
+    }
+  }
+
   it should "allow setting a limit using a prepared statement" in {
     val recipe = gen[Recipe]
     val limit = 1
@@ -62,6 +82,27 @@ class PreparedSelectQueryTest extends PhantomSuite {
     val query = database.recipes.select.where(_.url eqs ?).limit(?).prepare()
 
     val operation = for {
+      _ <- database.recipes.truncate.future
+      _ <- database.recipes.store(recipe).future()
+      select <- query.bind(recipe.url, limit).fetch()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
+    } yield (select, select2)
+
+    whenReady(operation) { case (items, items2) =>
+      items.size shouldEqual limit
+      items should contain (recipe)
+
+      items2 shouldBe defined
+      items2.value shouldEqual recipe
+    }
+  }
+
+  it should "allow setting a limit using an async prepared statement" in {
+    val recipe = gen[Recipe]
+    val limit = 1
+
+    val operation = for {
+      query <- database.recipes.select.where(_.url eqs ?).limit(?).prepareAsync()
       _ <- database.recipes.truncate.future
       _ <- database.recipes.store(recipe).future()
       select <- query.bind(recipe.url, limit).fetch()
@@ -94,19 +135,31 @@ class PreparedSelectQueryTest extends PhantomSuite {
     }
   }
 
-  it should "serialise and execute a prepared statement with 2 arguments" in {
+  it should "serialise and execute am async prepared select statement with the correct number of arguments" in {
+    val recipe = gen[Recipe]
+
+    val operation = for {
+      query <- database.recipes.select.where(_.url eqs ?).prepareAsync()
+      _ <- database.recipes.truncate.future
+      _ <- database.recipes.store(recipe).future()
+      select <- query.bind(recipe.url).one()
+    } yield select
+
+    whenReady(operation) { items =>
+      items shouldBe defined
+      items.value shouldEqual recipe
+    }
+  }
+
+  it should "serialise and execute an async prepared statement with 2 arguments" in {
     val sample = gen[Article]
     val sample2 = gen[Article]
     val owner = gen[UUID]
     val category = gen[UUID]
     val category2 = gen[UUID]
 
-    val query = database.articlesByAuthor.select
-      .where(_.author_id eqs ?)
-      .and(_.category eqs ?)
-      .prepare()
-
     val op = for {
+      query <- database.articlesByAuthor.select.where(_.author_id eqs ?).and(_.category eqs ?).prepareAsync()
       _ <- database.articlesByAuthor.store(owner, category, sample).future()
       _ <- database.articlesByAuthor.store(owner, category2, sample2).future()
       get <- query.bind(owner, category).one()
@@ -139,6 +192,23 @@ class PreparedSelectQueryTest extends PhantomSuite {
     }
   }
 
+
+  it should "serialise and execute an async primitives prepared select statement with the correct number of arguments" in {
+    val primitive = gen[PrimitiveRecord]
+
+    val operation = for {
+      query <- database.primitives.select.where(_.pkey eqs ?).prepareAsync()
+      _ <- database.primitives.truncate.future
+      _ <- database.primitives.store(primitive).future()
+      select <- query.bind(primitive.pkey).one()
+    } yield select
+
+    whenReady(operation) { items =>
+      items shouldBe defined
+      items.value shouldEqual primitive
+    }
+  }
+
   if (session.v4orNewer) {
     it should "serialise and execute a primitives cassandra 2.2 prepared select statement with the correct number of arguments" in {
       val primitive = gen[PrimitiveCassandra22]
@@ -146,6 +216,22 @@ class PreparedSelectQueryTest extends PhantomSuite {
       val query = database.primitivesCassandra22.select.where(_.pkey eqs ?).prepare()
 
       val operation = for {
+        _ <- database.primitivesCassandra22.truncate.future
+        _ <- database.primitivesCassandra22.store(primitive).future()
+        select <- query.bind(primitive.pkey).one()
+      } yield select
+
+      whenReady(operation) { items =>
+        items shouldBe defined
+        items.value shouldEqual primitive
+      }
+    }
+
+    it should "serialise and execute an async primitives cassandra 2.2 prepared select statement with the correct number of arguments" in {
+      val primitive = gen[PrimitiveCassandra22]
+
+      val operation = for {
+        query <- database.primitivesCassandra22.select.where(_.pkey eqs ?).prepareAsync()
         _ <- database.primitivesCassandra22.truncate.future
         _ <- database.primitivesCassandra22.store(primitive).future()
         select <- query.bind(primitive.pkey).one()

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedUpdateQueryTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedUpdateQueryTest.scala
@@ -45,20 +45,19 @@ class PreparedUpdateQueryTest extends PhantomSuite {
       get2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (get, get2)
 
-    whenReady(chain) {
-      case (initial, afterUpdate) => {
-        initial shouldBe defined
-        initial.value shouldEqual recipe
+    whenReady(chain) { case (initial, afterUpdate) =>
 
-        afterUpdate shouldBe defined
-        afterUpdate.value.url shouldEqual recipe.url
-        afterUpdate.value.props shouldEqual recipe.props
-        afterUpdate.value.ingredients shouldEqual recipe.ingredients
-        afterUpdate.value.servings shouldEqual recipe.servings
-        afterUpdate.value.lastCheckedAt shouldEqual recipe.lastCheckedAt
-        afterUpdate.value.uid shouldEqual recipe.uid
-        afterUpdate.value.description shouldEqual updated
-      }
+      initial shouldBe defined
+      initial.value shouldEqual recipe
+
+      afterUpdate shouldBe defined
+      afterUpdate.value.url shouldEqual recipe.url
+      afterUpdate.value.props shouldEqual recipe.props
+      afterUpdate.value.ingredients shouldEqual recipe.ingredients
+      afterUpdate.value.servings shouldEqual recipe.servings
+      afterUpdate.value.lastCheckedAt shouldEqual recipe.lastCheckedAt
+      afterUpdate.value.uid shouldEqual recipe.uid
+      afterUpdate.value.description shouldEqual updated
     }
   }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedUpdateQueryTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/PreparedUpdateQueryTest.scala
@@ -61,6 +61,35 @@ class PreparedUpdateQueryTest extends PhantomSuite {
     }
   }
 
+  it should "execute an asynchronous prepared update query with a single argument bind" in {
+    val updated = genOpt[ShortString].map(_.value)
+
+    val recipe = gen[Recipe]
+
+    val chain = for {
+      query <- database.recipes.update.where(_.url eqs ?).modify(_.description setTo ?).prepareAsync()
+      store <- database.recipes.store(recipe).future()
+      get <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- query.bind(updated, recipe.url).future()
+      get2 <- database.recipes.select.where(_.url eqs recipe.url).one()
+    } yield (get, get2)
+
+    whenReady(chain) { case (initial, afterUpdate) =>
+
+      initial shouldBe defined
+      initial.value shouldEqual recipe
+
+      afterUpdate shouldBe defined
+      afterUpdate.value.url shouldEqual recipe.url
+      afterUpdate.value.props shouldEqual recipe.props
+      afterUpdate.value.ingredients shouldEqual recipe.ingredients
+      afterUpdate.value.servings shouldEqual recipe.servings
+      afterUpdate.value.lastCheckedAt shouldEqual recipe.lastCheckedAt
+      afterUpdate.value.uid shouldEqual recipe.uid
+      afterUpdate.value.description shouldEqual updated
+    }
+  }
+
   it should "execute a prepared update query with a three argument bind" in {
 
     val updated = genOpt[ShortString].map(_.value)
@@ -95,6 +124,41 @@ class PreparedUpdateQueryTest extends PhantomSuite {
         afterUpdate.value.uid shouldEqual updatedUid
         afterUpdate.value.description shouldEqual updated
       }
+    }
+  }
+
+  it should "execute an async prepared update query with a three argument bind" in {
+
+    val updated = genOpt[ShortString].map(_.value)
+    val updatedUid = gen[UUID]
+
+    val recipe = gen[Recipe]
+
+    val chain = for {
+      query <- database.recipes
+        .update
+        .where(_.url eqs ?)
+        .modify(_.description setTo ?)
+        .and(_.uid setTo ?)
+        .prepareAsync()
+      store <- database.recipes.store(recipe).future()
+      get <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- query.bind(updated, updatedUid, recipe.url).future()
+      get2 <- database.recipes.select.where(_.url eqs recipe.url).one()
+    } yield (get, get2)
+
+    whenReady(chain) { case (initial, afterUpdate) =>
+      initial shouldBe defined
+      initial.value shouldEqual recipe
+
+      afterUpdate shouldBe defined
+      afterUpdate.value.url shouldEqual recipe.url
+      afterUpdate.value.props shouldEqual recipe.props
+      afterUpdate.value.ingredients shouldEqual recipe.ingredients
+      afterUpdate.value.servings shouldEqual recipe.servings
+      afterUpdate.value.lastCheckedAt shouldEqual recipe.lastCheckedAt
+      afterUpdate.value.uid shouldEqual updatedUid
+      afterUpdate.value.description shouldEqual updated
     }
   }
 }

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -23,7 +23,7 @@ import scala.util.Properties
 object Publishing {
 
   val defaultPublishingSettings = Seq(
-    version := "2.12.6"
+    version := "2.13.0"
   )
 
   lazy val noPublishSettings = Seq(


### PR DESCRIPTION
- Adding ability to asynchronously prepared queries
- De-coupled binding queries from preparing them.
- Added an `ExactlyOncePromise` that's meant to only execute the first time in any `map` or `flatMap` chain.