### PR TITLE
Hiding debug logs unless a flag is imported.

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/column/CounterColumn.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/column/CounterColumn.scala
@@ -16,7 +16,6 @@
 package com.outworkers.phantom.column
 
 import com.outworkers.phantom.builder.primitives.Primitive
-import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.syntax.CQLSyntax
 import com.outworkers.phantom.keys.Unmodifiable
 import com.outworkers.phantom.{CassandraTable, Row}
@@ -38,8 +37,6 @@ class CounterColumn[
   def parse(r: Row): Try[Long] = primitive.fromRow(name, r) recover {
     case e: Exception if r.isNull(name) => 0L
   }
-
-  override def qb: CQLQuery = CQLQuery(name).forcePad.append(cassandraType)
 
   override def asCql(v: Long): String = primitive.asCql(v)
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/column/CounterColumn.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/column/CounterColumn.scala
@@ -15,11 +15,11 @@
  */
 package com.outworkers.phantom.column
 
-import com.outworkers.phantom.{ CassandraTable, Row }
 import com.outworkers.phantom.builder.primitives.Primitive
 import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.syntax.CQLSyntax
 import com.outworkers.phantom.keys.Unmodifiable
+import com.outworkers.phantom.{CassandraTable, Row}
 
 import scala.util.Try
 
@@ -35,7 +35,9 @@ class CounterColumn[
 
   override val isCounterColumn = true
 
-  def parse(r: Row): Try[Long] = primitive.fromRow(name, r)
+  def parse(r: Row): Try[Long] = primitive.fromRow(name, r) recover {
+    case e: Exception if r.isNull(name) => 0L
+  }
 
   override def qb: CQLQuery = CQLQuery(name).forcePad.append(cassandraType)
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
@@ -25,8 +25,6 @@ import com.outworkers.phantom.macros.DatabaseHelper
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContextExecutor, Future, blocking}
 
-private object Lock
-
 abstract class Database[
   DB <: Database[DB]
 ](val connector: CassandraConnection)(implicit helper: DatabaseHelper[DB]) {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/BindHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/BindHelper.scala
@@ -16,7 +16,7 @@
 package com.outworkers.phantom.macros
 
 import com.datastax.driver.core.{BoundStatement, PreparedStatement, ProtocolVersion}
-import com.outworkers.phantom.macros.toolbelt.{BlackboxToolbelt, WhiteboxToolbelt}
+import com.outworkers.phantom.macros.toolbelt.WhiteboxToolbelt
 
 import scala.reflect.macros.whitebox
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/HListEqs.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/HListEqs.scala
@@ -16,9 +16,8 @@
 package com.outworkers.phantom.macros
 
 import com.outworkers.phantom.macros.toolbelt.WhiteboxToolbelt
-import shapeless.{HList, HNil}
+import shapeless.HList
 
-import scala.annotation.tailrec
 import scala.reflect.macros.whitebox
 
 /**

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
@@ -15,9 +15,10 @@
  */
 package com.outworkers.phantom.macros
 
-import com.outworkers.phantom.builder.query.sasi.{Analyzer, Mode}
+import com.outworkers.phantom.builder.query.sasi.Mode
 import com.outworkers.phantom.column.AbstractColumn
 import com.outworkers.phantom.keys.SASIIndex
+import com.outworkers.phantom.macros.toolbelt.WhiteboxToolbelt
 import com.outworkers.phantom.{CassandraTable, SelectTable}
 
 import scala.collection.generic.CanBuildFrom
@@ -25,7 +26,7 @@ import scala.collection.immutable.ListMap
 import scala.reflect.macros.whitebox
 
 @macrocompat.bundle
-trait RootMacro extends HListHelpers {
+trait RootMacro extends HListHelpers with WhiteboxToolbelt {
   val c: whitebox.Context
   import c.universe._
 
@@ -283,11 +284,8 @@ trait RootMacro extends HListHelpers {
         }
 
         val finalDefinitions = unmatchedColumnInserts ++ insertions
-        c.info(
-          c.enclosingPosition,
-          s"Inferred store input type: ${printType(sTpe)} for ${printType(tableTpe)}",
-          force = false
-        )
+
+        info(s"Inferred store input type: ${printType(sTpe)} for ${printType(tableTpe)}")
 
         val tree = q"""$tableTerm.insert.values(..$finalDefinitions)"""
         Some(tree)
@@ -327,11 +325,7 @@ trait RootMacro extends HListHelpers {
       if (unmatchedColumns.isEmpty) {
         Some(mkHListType(recordType :: Nil))
       } else {
-        c.info(
-          c.enclosingPosition,
-          s"Found unmatched columns for ${printType(tableTpe)}: ${debugList(unmatchedColumns)}",
-          force = false
-        )
+        info(s"Found unmatched columns for ${printType(tableTpe)}: ${debugList(unmatchedColumns)}")
 
         val cols = unmatchedColumns.map(_.tpe) :+ recordType
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/debug/package.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/debug/package.scala
@@ -21,6 +21,7 @@ package object debug {
     sealed trait ShowCache
     sealed trait ShowAborts
     sealed trait ShowBoundStatements
+    sealed trait ShowCompileLog
   }
 
 
@@ -31,6 +32,12 @@ package object debug {
       * to the console during compilation
       */
     implicit object ShowTrees extends optionTypes.ShowTrees
+
+    /**
+      * Shows the internal compilation log for phantom tables.
+      * If this is not imported all the c.info level logs are hidden.
+      */
+    implicit object ShowLog extends optionTypes.ShowCompileLog
 
     /**
       * Import this value to have Iota print the cached computations

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/toolbelt/BlackboxToolbelt.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/toolbelt/BlackboxToolbelt.scala
@@ -44,15 +44,8 @@ private[phantom] trait BlackboxToolbelt {
 
   import c.universe._
 
-  def info(msg: String, force: Boolean = false): Unit = c.info(c.enclosingPosition, msg, force)
-
-  def error(msg: String): Unit = c.error(c.enclosingPosition, msg)
-
-  def echo(msg: String): Unit = c.echo(c.enclosingPosition, msg)
-
-  def warning(msg: String): Unit = c.warning(c.enclosingPosition, msg)
-
-  def abort(msg: String): Nothing = c.abort(c.enclosingPosition, msg)
+  lazy val showLogs =
+    !c.inferImplicitValue(typeOf[debug.optionTypes.ShowCompileLog], silent = true).isEmpty
 
   lazy val showAborts =
     !c.inferImplicitValue(typeOf[debug.optionTypes.ShowAborts], silent = true).isEmpty
@@ -82,4 +75,24 @@ private[phantom] trait BlackboxToolbelt {
         b
     }
   }
+
+  def info(msg: String, force: Boolean = false): Unit = {
+    if (showLogs) {
+      c.info(c.enclosingPosition, msg, force)
+    }
+  }
+
+  def echo(msg: String): Unit = {
+    if (showLogs) {
+      c.echo(c.enclosingPosition, msg)
+    }
+  }
+
+  def error(msg: String): Unit = c.error(c.enclosingPosition, msg)
+
+
+  def warning(msg: String): Unit = c.warning(c.enclosingPosition, msg)
+
+  def abort(msg: String): Nothing = c.abort(c.enclosingPosition, msg)
+
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/toolbelt/WhiteboxToolbelt.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/toolbelt/WhiteboxToolbelt.scala
@@ -44,15 +44,10 @@ private[phantom] trait WhiteboxToolbelt {
 
   import c.universe._
 
-  def info(msg: String, force: Boolean = false): Unit = c.info(c.enclosingPosition, msg, force)
-
-  def error(msg: String): Unit = c.error(c.enclosingPosition, msg)
-
-  def echo(msg: String): Unit = c.echo(c.enclosingPosition, msg)
-
-  def warning(msg: String): Unit = c.warning(c.enclosingPosition, msg)
-
   def abort(msg: String): Nothing = c.abort(c.enclosingPosition, msg)
+
+  lazy val showLogs =
+    !c.inferImplicitValue(typeOf[debug.optionTypes.ShowCompileLog], silent = true).isEmpty
 
   lazy val showAborts =
     !c.inferImplicitValue(typeOf[debug.optionTypes.ShowAborts], silent = true).isEmpty
@@ -82,4 +77,23 @@ private[phantom] trait WhiteboxToolbelt {
         b
     }
   }
+
+
+  def info(msg: String, force: Boolean = false): Unit = {
+    if (showLogs) {
+      c.info(c.enclosingPosition, msg, force)
+    }
+  }
+
+  def echo(msg: String): Unit = {
+    if (showLogs) {
+      c.echo(c.enclosingPosition, msg)
+    }
+  }
+
+  def error(msg: String): Unit = c.error(c.enclosingPosition, msg)
+
+
+  def warning(msg: String): Unit = c.warning(c.enclosingPosition, msg)
+
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/PhantomSuite.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/PhantomSuite.scala
@@ -18,7 +18,6 @@ package com.outworkers.phantom
 import java.util.concurrent.TimeUnit
 
 import com.datastax.driver.core.VersionNumber
-import com.outworkers.phantom.connectors.RootConnector
 import com.outworkers.phantom.database.DatabaseProvider
 import com.outworkers.phantom.tables.TestDatabase
 import org.json4s.Formats

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/batch/BatchTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/batch/BatchTest.scala
@@ -20,8 +20,6 @@ import com.outworkers.util.samplers._
 import com.outworkers.phantom.dsl._
 import com.outworkers.phantom.tables.JodaRow
 import org.joda.time.DateTime
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 class BatchTest extends PhantomSuite {
 
@@ -32,6 +30,7 @@ class BatchTest extends PhantomSuite {
 
   it should "get the correct count for batch queries" in {
     val row = gen[JodaRow]
+
     val statement3 = database.primitivesJoda.update
       .where(_.pkey eqs row.pkey)
       .modify(_.intColumn setTo row.intColumn)
@@ -42,6 +41,7 @@ class BatchTest extends PhantomSuite {
 
     val batch = Batch.logged.add(statement3, statement4)
 
+    batch.iterator.size shouldEqual 2
   }
 
   ignore should "serialize a multiple table batch query applied to multiple statements" in {
@@ -176,8 +176,6 @@ class BatchTest extends PhantomSuite {
       .where(_.pkey eqs row3.pkey)
 
     val batch = Batch.logged.add(statement3).add(statement4)
-
-    //Await.result(batch.future(), 10.seconds)
 
     val chain = for {
       s1 <- database.primitivesJoda.store(row).future()

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/TTLTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/TTLTest.scala
@@ -16,7 +16,6 @@
 package com.outworkers.phantom.builder.query.db.crud
 
 import com.outworkers.phantom.PhantomSuite
-import com.outworkers.phantom.builder.query.prepared._
 import com.outworkers.phantom.dsl._
 import com.outworkers.phantom.tables.PrimitiveRecord
 import com.outworkers.util.samplers._

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/TruncateTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/crud/TruncateTest.scala
@@ -20,8 +20,6 @@ import com.outworkers.phantom.dsl._
 import com.outworkers.phantom.tables._
 import com.outworkers.util.samplers._
 
-import scala.concurrent.Future
-
 class TruncateTest extends PhantomSuite {
 
   override def beforeAll(): Unit = {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/ordering/OrderByTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/ordering/OrderByTest.scala
@@ -19,12 +19,9 @@ import java.util.UUID
 
 import com.datastax.driver.core.utils.UUIDs
 import com.outworkers.phantom.PhantomSuite
-import com.outworkers.phantom.tables.{TestDatabase, TimeUUIDRecord}
-import com.outworkers.util.samplers._
 import com.outworkers.phantom.dsl._
-import org.joda.time.{DateTime, DateTimeZone}
-
-import scala.concurrent.Future
+import com.outworkers.phantom.tables.TimeUUIDRecord
+import com.outworkers.util.samplers._
 
 class OrderByTest extends PhantomSuite {
 
@@ -48,27 +45,26 @@ class OrderByTest extends PhantomSuite {
     } yield (get, desc)
 
 
-    whenReady(chain) {
-      case (asc, desc) =>
-        val orderedAsc = records.sortWith((a, b) => { a.id.compareTo(b.id) <= 0 })
+    whenReady(chain) { case (asc, desc) =>
+      val orderedAsc = records.sortWith((a, b) => { a.id.compareTo(b.id) <= 0 })
 
-        info("The ascending results retrieved from the DB")
-        info(asc.mkString("\n"))
+      info("The ascending results retrieved from the DB")
+      info(asc.mkString("\n"))
 
-        info("The ascending results expected")
-        info(orderedAsc.mkString("\n"))
+      info("The ascending results expected")
+      info(orderedAsc.mkString("\n"))
 
-        asc should contain theSameElementsAs orderedAsc
+      asc should contain theSameElementsAs orderedAsc
 
-        val orderedDesc = records.sortWith((a, b) => { a.id.compareTo(b.id) >= 0 })
+      val orderedDesc = records.sortWith((a, b) => { a.id.compareTo(b.id) >= 0 })
 
-        info("The descending results retrieved from the DB")
-        info(desc.mkString("\n"))
+      info("The descending results retrieved from the DB")
+      info(desc.mkString("\n"))
 
-        info("The descending results expected")
-        info(orderedDesc.mkString("\n"))
+      info("The descending results expected")
+      info(orderedDesc.mkString("\n"))
 
-        desc should contain theSameElementsAs orderedDesc
+      desc should contain theSameElementsAs orderedDesc
     }
   }
 

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/specialized/ConditionalQueriesTest.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/db/specialized/ConditionalQueriesTest.scala
@@ -17,16 +17,14 @@ package com.outworkers.phantom.builder.query.db.specialized
 
 import com.outworkers.phantom.PhantomSuite
 import com.outworkers.phantom.dsl._
-import com.outworkers.phantom.tables.{Recipe, TestDatabase}
+import com.outworkers.phantom.tables.Recipe
 import com.outworkers.util.samplers._
-
-import scala.concurrent.duration._
 
 class ConditionalQueriesTest extends PhantomSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    TestDatabase.recipes.create.ifNotExists().future().block(defaultScalaTimeout)
+    database.recipes.create.ifNotExists().future().block(defaultScalaTimeout)
   }
 
   it should "update the record if the optional column based condition matches" in {
@@ -35,28 +33,26 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.description is recipe.description).future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
-        info("The first record should not be empty")
-        initial shouldBe defined
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        initial shouldBe defined
+      info("The updated record should not be empty")
+      initial shouldBe defined
 
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 
@@ -66,28 +62,26 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.ingredients is recipe.ingredients).future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
-        info("The first record should not be empty")
-        initial shouldBe defined
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        initial shouldBe defined
+      info("The updated record should not be empty")
+      initial shouldBe defined
 
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 
@@ -97,28 +91,26 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.ingredients is invalidMatch).future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
-        info("The first record should not be empty")
-        initial shouldBe defined
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        second shouldBe defined
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("And it shouldn't have updated the value")
-        second.value.description shouldNot equal(updated)
-      }
+      info("And it shouldn't have updated the value")
+      second.value.description shouldNot equal(updated)
     }
   }
 
@@ -128,29 +120,27 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.description is updated).future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
+    whenReady(chain) { case (initial, second) =>
 
-        info("The first record should not be empty")
-        initial shouldBe defined
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        second shouldBe defined
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldNot equal(updated)
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldNot equal(updated)
     }
   }
 
@@ -160,31 +150,29 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.description is recipe.description)
         .and(_.uid is recipe.uid).future()
 
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
+    whenReady(chain) { case (initial, second) =>
 
-        info("The first record should not be empty")
-        initial shouldBe defined
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        second shouldBe defined
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 
@@ -194,31 +182,28 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.description is recipe.description)
         .and(_.lastcheckedat is recipe.lastCheckedAt)
         .and(_.uid is recipe.uid).future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("The first record should not be empty")
-        initial shouldBe defined
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("The updated record should not be empty")
-        second shouldBe defined
-
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 
@@ -228,31 +213,28 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.props is recipe.props)
         .and(_.ingredients is recipe.ingredients)
         .future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("The first record should not be empty")
-        initial shouldBe defined
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("The updated record should not be empty")
-        second shouldBe defined
-
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 
@@ -262,31 +244,29 @@ class ConditionalQueriesTest extends PhantomSuite {
     val updated = genOpt[String]
 
     val chain = for {
-      insert <- TestDatabase.recipes.store(recipe).future()
-      select1 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
-      update <- TestDatabase.recipes.update.where(_.url eqs recipe.url)
+      insert <- database.recipes.store(recipe).future()
+      select1 <- database.recipes.select.where(_.url eqs recipe.url).one()
+      update <- database.recipes.update.where(_.url eqs recipe.url)
         .modify(_.description setTo updated)
         .onlyIf(_.props is recipe.props)
         .and(_.uid is recipe.uid)
         .and(_.ingredients is recipe.ingredients)
         .future()
-      select2 <- TestDatabase.recipes.select.where(_.url eqs recipe.url).one()
+      select2 <- database.recipes.select.where(_.url eqs recipe.url).one()
     } yield (select1, select2)
 
-    whenReady(chain) {
-      case (initial, second) => {
-        info("The first record should not be empty")
-        initial shouldBe defined
+    whenReady(chain) { case (initial, second) =>
+      info("The first record should not be empty")
+      initial shouldBe defined
 
-        info("And it should match the inserted values")
-        initial.value.url shouldEqual recipe.url
+      info("And it should match the inserted values")
+      initial.value.url shouldEqual recipe.url
 
-        info("The updated record should not be empty")
-        second shouldBe defined
+      info("The updated record should not be empty")
+      second shouldBe defined
 
-        info("And it should contain the updated value of the uid")
-        second.value.description shouldEqual updated
-      }
+      info("And it should contain the updated value of the uid")
+      second.value.description shouldEqual updated
     }
   }
 }


### PR DESCRIPTION
- Removing some obsolete imports.
- Using `WhiteboxToolbelt` in `RootMacro`.
- Hiding all compilation logs by default unless explicit import is found.