### PR TITLE
Feature/removing cats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jdk:
 - oraclejdk8
 matrix:
   include:
-  - scala: 2.12.2
+  - scala: 2.12.3
     jdk: oraclejdk8
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Migrating to phantom 2.14.0(phantom-finagle users)
 =================================
 
 Please refer to the new docs on query execution to understand the breaking changes in phantom 2.14.0. They will
-affect users of `phantom-finagle`. Details [here](docs/querying/execution.md)
+affect users of `phantom-finagle`. Details [here](docs/querying/execution.md).
+
+Even if you do not use `phantom-finagle` but just the normal `phantom-dsl`, `import com.outworkers.phantom.dsl._` is
+ now required in more places than before. The `future` method is no longer implementation by query classes, but
+ rather added via implicit augmentation by `QueryContext`. The return type of the `future` method is now dependent
+ on which `QueryContext` you use, so that's why importing is required, without it the necessary implicits will not
+ be in scope.
 
 
 Migrating to phantom 2.x.x series

--- a/build.sbt
+++ b/build.sbt
@@ -205,7 +205,6 @@ lazy val phantomDsl = (project in file("phantom-dsl"))
       "org.typelevel" %% "macro-compat" % Versions.macrocompat,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
       compilerPlugin("org.scalamacros" % "paradise" % Versions.macroParadise cross CrossVersion.full),
-      "org.typelevel"                %% "cats"                              % "0.9.0",
       "com.chuusai"                  %% "shapeless"                         % Versions.shapeless,
       "joda-time"                    %  "joda-time"                         % Versions.joda,
       "org.joda"                     %  "joda-convert"                      % Versions.jodaConvert,

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -15,12 +15,11 @@
  */
 package com.outworkers.phantom
 
-import cats.Monad
 import com.datastax.driver.core.Session
 import com.outworkers.phantom.builder.QueryBuilder
 import com.outworkers.phantom.builder.clauses.DeleteClause
 import com.outworkers.phantom.builder.primitives.Primitive
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, ExecutableStatements, GuavaAdapter, QueryCollection}
+import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, ExecutableStatements, FutureMonad, GuavaAdapter, QueryCollection}
 import com.outworkers.phantom.builder.query.sasi.Mode
 import com.outworkers.phantom.builder.query.{RootCreateQuery, _}
 import com.outworkers.phantom.column.AbstractColumn
@@ -61,7 +60,7 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
     implicit session: Session,
     keySpace: KeySpace,
     ec: ExecutionContextExecutor,
-    monad: Monad[F],
+    monad: FutureMonad[F],
     guavaAdapter: GuavaAdapter[F]
   ): F[Seq[ResultSet]] = {
     new ExecutableStatements[F, Seq](autocreate(keySpace).queries).sequence()

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
@@ -15,18 +15,26 @@
  */
 package com.outworkers.phantom
 
-import cats.Monad
-import cats.instances.future._
-import com.outworkers.phantom.builder.query.execution.PromiseInterface
+import com.outworkers.phantom.builder.query.execution.{FutureMonad, PromiseInterface}
 import com.outworkers.phantom.ops.QueryContext
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Await, ExecutionContextExecutor, Future, Promise}
 
 object ScalaFutureImplicits {
 
-  val monadInstance: Monad[Future] = catsStdInstancesForFuture(Manager.scalaExecutor)
+  implicit val monadInstance: FutureMonad[Future] = new FutureMonad[Future] {
 
+    override def flatMap[A, B](source: Future[A])(fn: (A) => Future[B])(
+      implicit ctx: ExecutionContextExecutor
+    ): Future[B] = source flatMap fn
+
+    override def map[A, B](source: Future[A])(f: (A) => B)(
+      implicit ctx: ExecutionContextExecutor
+    ): Future[B] = source map f
+
+    override def pure[A](source: A): Future[A] = Future.successful(source)
+  }
 }
 
 object ScalaPromiseInterface extends PromiseInterface[Promise, Future] {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
@@ -36,7 +36,7 @@ object ScalaPromiseInterface extends PromiseInterface[Promise, Future] {
 
   override def future[T](source: Promise[T]): Future[T] = source.future
 
-  override def failed[T](exception: Exception): Future[T] = Future.failed[T](exception)
+  override def failed[T](exception: Throwable): Future[T] = Future.failed[T](exception)
 
   override def apply[T](value: T): Future[T] = Future.successful(value)
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
@@ -21,7 +21,6 @@ import com.outworkers.phantom.builder.clauses._
 import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.ops.MapKeyUpdateClause
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, FutureMonad, GuavaAdapter, PromiseInterface}
 import com.outworkers.phantom.builder.query.prepared.{PreparedBlock, PreparedFlattener}
 import com.outworkers.phantom.column.AbstractColumn
 import com.outworkers.phantom.connectors.KeySpace

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
@@ -15,21 +15,20 @@
  */
 package com.outworkers.phantom.builder.query
 
-import cats.Monad
 import com.datastax.driver.core.{ConsistencyLevel, Session}
-import com.outworkers.phantom.{CassandraTable, Row}
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.clauses._
+import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.ops.MapKeyUpdateClause
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, GuavaAdapter, PromiseInterface}
-import com.outworkers.phantom.builder.query.prepared.{PreparedBlock, PreparedFlattener, PreparedSelectBlock}
+import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, FutureMonad, GuavaAdapter, PromiseInterface}
+import com.outworkers.phantom.builder.query.prepared.{PreparedBlock, PreparedFlattener}
 import com.outworkers.phantom.column.AbstractColumn
 import com.outworkers.phantom.connectors.KeySpace
+import com.outworkers.phantom.{CassandraTable, Row}
 import org.joda.time.DateTime
 import shapeless.ops.hlist.{Prepend, Reverse}
 import shapeless.{=:!=, HList, HNil}
-import cats.syntax.functor._
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -93,7 +92,7 @@ case class DeleteQuery[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    monad: Monad[F],
+    monad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Rev]] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -15,18 +15,16 @@
  */
 package com.outworkers.phantom.builder.query
 
-import cats.Monad
-import cats.syntax.functor._
 import com.datastax.driver.core.{ConsistencyLevel, Session}
 import com.outworkers.phantom.CassandraTable
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.clauses.{OperatorClause, UsingClause}
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, GuavaAdapter, PromiseInterface}
+import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.query.prepared.{PrepareMark, PreparedBlock, PreparedFlattener}
 import com.outworkers.phantom.builder.syntax.CQLSyntax
 import com.outworkers.phantom.column.AbstractColumn
-import com.outworkers.phantom.connectors.{KeySpace, SessionAugmenterImplicits}
+import com.outworkers.phantom.connectors.KeySpace
 import org.joda.time.DateTime
 import shapeless.ops.hlist.Reverse
 import shapeless.{::, =:!=, HList, HNil}
@@ -130,7 +128,7 @@ case class InsertQuery[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Rev]] = {
@@ -246,7 +244,7 @@ class InsertJsonQuery[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Rev]] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
@@ -15,13 +15,11 @@
  */
 package com.outworkers.phantom.builder.query
 
-import cats.Monad
-import cats.syntax.functor._
 import com.datastax.driver.core.{ConsistencyLevel, Session}
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.clauses._
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, GuavaAdapter, PromiseInterface}
+import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.query.prepared.{PrepareMark, PreparedBlock, PreparedFlattener}
 import com.outworkers.phantom.connectors.KeySpace
 import com.outworkers.phantom.{CassandraTable, Row}
@@ -77,7 +75,7 @@ case class UpdateQuery[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Rev]] = {
@@ -276,7 +274,7 @@ sealed case class AssignmentsQuery[
     rev: Reverse.Aux[PS, Rev],
     rev2: Reverse.Aux[ModifyPrepared, Reversed],
     prepend: Prepend.Aux[Reversed, Rev, Out],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Out]] = {
@@ -392,7 +390,7 @@ sealed case class ConditionalQuery[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedBlock[Rev]] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/ExactlyOncePromise.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/ExactlyOncePromise.scala
@@ -17,8 +17,6 @@ package com.outworkers.phantom.builder.query.execution
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import cats.Monad
-import cats.syntax.functor._
 import com.datastax.driver.core.{Session, Statement}
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
 import com.outworkers.phantom.ResultSet
@@ -38,7 +36,7 @@ trait PromiseInterface[P[_], F[_]] {
 
   def failed[T](exception: Throwable): F[T]
 
-  def adapter(implicit monad: Monad[F]): GuavaAdapter[F] = new GuavaAdapter[F] with SessionAugmenterImplicits {
+  def adapter(implicit monad: FutureMonad[F]): GuavaAdapter[F] = new GuavaAdapter[F] with SessionAugmenterImplicits {
 
     override def fromGuava[T](source: ListenableFuture[T])(
       implicit executor: ExecutionContextExecutor
@@ -69,7 +67,7 @@ trait PromiseInterface[P[_], F[_]] {
 class ExactlyOncePromise[P[_], F[_], T](
   fn: => F[T]
 )(
-  implicit fMonad: Monad[F],
+  implicit fMonad: FutureMonad[F],
   interface: PromiseInterface[P, F]
 ) {
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/ExactlyOncePromise.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/ExactlyOncePromise.scala
@@ -18,6 +18,13 @@ package com.outworkers.phantom.builder.query.execution
 import java.util.concurrent.atomic.AtomicBoolean
 
 import cats.Monad
+import cats.syntax.functor._
+import com.datastax.driver.core.{Session, Statement}
+import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import com.outworkers.phantom.ResultSet
+import com.outworkers.phantom.connectors.SessionAugmenterImplicits
+
+import scala.concurrent.ExecutionContextExecutor
 
 trait PromiseInterface[P[_], F[_]] {
 
@@ -29,7 +36,34 @@ trait PromiseInterface[P[_], F[_]] {
 
   def future[T](source: P[T]): F[T]
 
-  def failed[T](exception: Exception): F[T]
+  def failed[T](exception: Throwable): F[T]
+
+  def adapter(implicit monad: Monad[F]): GuavaAdapter[F] = new GuavaAdapter[F] with SessionAugmenterImplicits {
+
+    override def fromGuava[T](source: ListenableFuture[T])(
+      implicit executor: ExecutionContextExecutor
+    ): F[T] = {
+      val promise = empty[T]
+
+      val callback = new FutureCallback[T] {
+        def onSuccess(result: T): Unit = {
+          become(promise, apply(result))
+        }
+
+        def onFailure(err: Throwable): Unit = {
+          become(promise, failed(err))
+        }
+      }
+
+      Futures.addCallback(source, callback, executor)
+      future(promise)
+    }
+
+    override def fromGuava(in: Statement)(
+      implicit session: Session,
+      ctx: ExecutionContextExecutor
+    ): F[ResultSet] = fromGuava(session.executeAsync(in)).map(res => ResultSet(res, session.protocolVersion))
+  }
 }
 
 class ExactlyOncePromise[P[_], F[_], T](

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 - 2017 Outworkers Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.outworkers.phantom.builder.query.execution
+
+import scala.concurrent.ExecutionContextExecutor
+
+/**
+  * A special mini monad implementation that allows us not to have to rely on Cats being
+  * part of our dependencies as it's really heavy to use for this simple reason.
+  * Cats also requires binding a future monad for Scala futures against a known [[ExecutionContextExecutor]],
+  * which unfortunately interferes with one of the core features in phantom, giving users the ability
+  * to supply their own execution context whenever they want.
+  *
+  * In our implementation, we go against the grain and include the implicit [[ExecutionContextExecutor]] as part
+  * of the standard method signature for map and flatMap, and this is only because we want to keep enabling users
+  * to supply their own context. Certain implementations of Futures will downright ignore this implicit parameter,
+  * but it's there for the implementations of Future and Promise that need it, specifically Scala Standard Lib
+  * [[scala.concurrent.Future]] and [[scala.concurrent.Promise]].
+  *
+  * Cats is a much better library in any conceivable way, and while we are not trying to reinvent category theory,
+  * it's too heavy of a dependency to add for the sake of a single simple typeclass.
+  *
+  * @tparam F The type of the Future implementation for which we implement map and flatMap.
+  */
+trait FutureMonad[F[_]] {
+
+  def pure[A](source: A): F[A]
+
+  def map[A, B](source: F[A])(f: A => B)(
+    implicit ctx: ExecutionContextExecutor
+  ): F[B]
+
+  def flatMap[A, B](source: F[A])(fn: A => F[B])(
+    implicit ctx: ExecutionContextExecutor
+  ): F[B]
+}

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/package.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/package.scala
@@ -15,15 +15,23 @@
  */
 package com.outworkers.phantom.builder.query
 
-import cats.Monad
-import cats.implicits._
+import scala.concurrent.ExecutionContextExecutor
 
 package object execution {
 
-  implicit class FunctorOps[F[_], T](val in: F[T])(implicit fMonad: Monad[F]) {
-    def zipWith[O, R](other: F[O])(fn: (T, O) => R): F[R] = {
+  implicit class FunctorOps[F[_], T](val in: F[T])(implicit fMonad: FutureMonad[F]) {
+    def zipWith[O, R](other: F[O])(fn: (T, O) => R)(
+      implicit ctx: ExecutionContextExecutor
+    ): F[R] = {
       for (r1 <- in; r2 <- other) yield fn(r1, r2)
     }
-  }
 
+    def map[A](fn: T => A)(
+      implicit ctx: ExecutionContextExecutor
+    ): F[A] = fMonad.map(in)(fn)
+
+    def flatMap[A](fn: T => F[A])(
+      implicit ctx: ExecutionContextExecutor
+    ): F[A] = fMonad.flatMap(in)(fn)
+  }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -15,13 +15,12 @@
  */
 package com.outworkers.phantom.builder.query.prepared
 
-import cats.Monad
 import com.datastax.driver.core.{QueryOptions => _, _}
 import com.outworkers.phantom.builder.LimitBound
 import com.outworkers.phantom.builder.primitives.Primitive
 import com.outworkers.phantom.builder.query._
 import com.outworkers.phantom.builder.query.engine.CQLQuery
-import com.outworkers.phantom.builder.query.execution.{ExactlyOncePromise, ExecutableCqlQuery, GuavaAdapter, PromiseInterface}
+import com.outworkers.phantom.builder.query.execution.{ExactlyOncePromise, ExecutableCqlQuery, FutureMonad, GuavaAdapter, PromiseInterface}
 import com.outworkers.phantom.connectors.{KeySpace, SessionAugmenterImplicits}
 import com.outworkers.phantom.macros.BindHelper
 import com.outworkers.phantom.{CassandraTable, Row}
@@ -69,7 +68,7 @@ class PreparedFlattener(qb: CQLQuery)(
 
   def async[P[_], F[_]]()(
     implicit executor: ExecutionContextExecutor,
-    monad: Monad[F],
+    monad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedStatement] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/database/Database.scala
@@ -22,7 +22,6 @@ import com.outworkers.phantom.connectors.{CassandraConnection, KeySpace}
 import com.outworkers.phantom.macros.DatabaseHelper
 
 import scala.concurrent.blocking
-import scala.collection.immutable.Seq
 
 abstract class Database[
   DB <: Database[DB]

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/dsl/package.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/dsl/package.scala
@@ -15,9 +15,6 @@
  */
 package com.outworkers.phantom
 
-import cats.Monad
-import cats.instances.FutureInstances
-import com.datastax.driver.core.Statement
 import com.outworkers.phantom.builder.query.QueryOptions
 import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.query.execution._
@@ -25,13 +22,13 @@ import com.outworkers.phantom.builder.query.execution._
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{ExecutionContextExecutor, Future}
 
-package object dsl extends ScalaQueryContext with DefaultImports with FutureInstances {
+package object dsl extends ScalaQueryContext with DefaultImports {
 
   implicit class ExecuteQueries[M[X] <: TraversableOnce[X]](val qc: QueryCollection[M]) extends AnyVal {
     def executable()(
       implicit ctx: ExecutionContextExecutor
     ): ExecutableStatements[Future, M] = {
-      implicit val fMonad: Monad[Future] = catsStdInstancesForFuture(ctx)
+      import ScalaFutureImplicits._
       new ExecutableStatements[Future, M](qc)
     }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/dsl/package.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/dsl/package.scala
@@ -20,15 +20,14 @@ import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.query.execution._
 
 import scala.collection.generic.CanBuildFrom
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.Future
 
 package object dsl extends ScalaQueryContext with DefaultImports {
 
+  implicit val futureMonad: FutureMonad[Future] = ScalaFutureImplicits.monadInstance
+
   implicit class ExecuteQueries[M[X] <: TraversableOnce[X]](val qc: QueryCollection[M]) extends AnyVal {
-    def executable()(
-      implicit ctx: ExecutionContextExecutor
-    ): ExecutableStatements[Future, M] = {
-      import ScalaFutureImplicits._
+    def executable(): ExecutableStatements[Future, M] = {
       new ExecutableStatements[Future, M](qc)
     }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/DatabaseHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/DatabaseHelper.scala
@@ -22,7 +22,6 @@ import com.outworkers.phantom.database.Database
 import com.outworkers.phantom.macros.toolbelt.WhiteboxToolbelt
 
 import scala.reflect.macros.whitebox
-import scala.collection.immutable.Seq
 
 trait DatabaseHelper[T <: Database[T]] {
   def tables(db: T): Seq[CassandraTable[_ ,_]]
@@ -41,12 +40,12 @@ class DatabaseHelperMacro(override val c: whitebox.Context) extends WhiteboxTool
   import c.universe._
 
   private[this] val seqTpe: Type => Tree = { tpe =>
-    tq"_root_.scala.collection.immutable.Seq[$tpe]"
+    tq"_root_.scala.collection.Seq[$tpe]"
   }
 
   private[this] val tableSymbol = typeOf[com.outworkers.phantom.CassandraTable[_, _]]
 
-  private[this] val seqCmp = q"_root_.scala.collection.immutable.Seq"
+  private[this] val seqCmp = q"_root_.scala.collection.Seq"
 
   def materialize[T <: Database[T] : WeakTypeTag]: Tree = {
     memoize[Type, Tree](WhiteboxToolbelt.ddHelperCache)(weakTypeOf[T], deriveHelper)
@@ -72,7 +71,7 @@ class DatabaseHelperMacro(override val c: whitebox.Context) extends WhiteboxTool
 
          def createQueries(db: $tpe)(
            implicit space: $keyspaceType
-         ): $execution.QueryCollection[_root_.scala.collection.immutable.Seq] = {
+         ): $execution.QueryCollection[_root_.scala.collection.Seq] = {
             new $execution.QueryCollection($seqCmp.apply(..$queryList))
          }
        }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
@@ -15,16 +15,15 @@
  */
 package com.outworkers.phantom.ops
 
-import cats.Monad
 import com.outworkers.phantom.ResultSet
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, ExecutableStatements, QueryCollection}
+import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, ExecutableStatements, FutureMonad, QueryCollection}
 import com.outworkers.phantom.database.Database
 
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.ExecutionContextExecutor
 
 abstract class DbOps[
-  F[_] : Monad,
+  F[_] : FutureMonad,
   DB <: Database[DB],
   Timeout
 ](val db: Database[DB]) {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
@@ -22,7 +22,6 @@ import com.outworkers.phantom.database.Database
 
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.ExecutionContextExecutor
-import scala.collection.immutable.Seq
 
 abstract class DbOps[
   F[_] : Monad,

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
@@ -15,9 +15,6 @@
  */
 package com.outworkers.phantom.ops
 
-import cats.Monad
-import cats.syntax.functor._
-import cats.syntax.flatMap._
 import com.datastax.driver.core.{Session, Statement}
 import com.outworkers.phantom.builder.batch.BatchQuery
 import com.outworkers.phantom.builder._
@@ -37,7 +34,7 @@ import scala.concurrent.ExecutionContextExecutor
 abstract class QueryContext[P[_], F[_], Timeout](
   defaultTimeout: Timeout
 )(
-  implicit fMonad: Monad[F],
+  implicit fMonad: FutureMonad[F],
   val promiseInterface: PromiseInterface[P, F],
   val adapter: GuavaAdapter[F]
 ) { outer =>

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
@@ -18,7 +18,6 @@ package com.outworkers.phantom.ops
 import com.datastax.driver.core.{Session, Statement}
 import com.outworkers.phantom.builder.batch.BatchQuery
 import com.outworkers.phantom.builder._
-import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.query.prepared.{ExecutablePreparedQuery, ExecutablePreparedSelectQuery}
 import com.outworkers.phantom.builder.query._
@@ -67,7 +66,9 @@ abstract class QueryContext[P[_], F[_], Timeout](
   implicit class RootSelectBlockOps[
     Table <: CassandraTable[Table, Record],
     Record
-  ](val block: RootSelectBlock[Table, Record])(implicit keySpace: KeySpace) extends ResultQueryInterface[F, Table, Record, Unlimited] {
+  ](val block: RootSelectBlock[Table, Record])(
+    implicit keySpace: KeySpace
+  ) extends ResultQueryInterface[F, Table, Record, Unlimited] {
     override def fromRow(r: Row): Record = block.rowFunc(r)
 
     /**

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 package com.outworkers.phantom.ops
-import com.outworkers.phantom.builder.query.execution._
 import com.datastax.driver.core.Session
 import com.outworkers.phantom.builder._
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, FutureMonad, GuavaAdapter, PromiseInterface, ResultQueryInterface}
+import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.builder.query.prepared.{PreparedFlattener, PreparedSelectBlock}
 import com.outworkers.phantom.builder.query.{LimitedPart, SelectQuery}
 import com.outworkers.phantom.connectors.KeySpace

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 package com.outworkers.phantom.ops
-
-import cats.Monad
-import cats.syntax.functor._
+import com.outworkers.phantom.builder.query.execution._
 import com.datastax.driver.core.Session
 import com.outworkers.phantom.builder._
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, GuavaAdapter, PromiseInterface, ResultQueryInterface}
+import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, FutureMonad, GuavaAdapter, PromiseInterface, ResultQueryInterface}
 import com.outworkers.phantom.builder.query.prepared.{PreparedFlattener, PreparedSelectBlock}
 import com.outworkers.phantom.builder.query.{LimitedPart, SelectQuery}
 import com.outworkers.phantom.connectors.KeySpace
@@ -44,7 +42,7 @@ class SelectQueryOps[
   val query: SelectQuery[Table, Record, Limit, Order, Status, Chain, PS]
 )(
   implicit adapter: GuavaAdapter[F],
-  fMonad: Monad[F]
+  fMonad: FutureMonad[F]
 ) extends ResultQueryInterface[F, Table, Record, Limit] {
 
   /**
@@ -90,7 +88,7 @@ class SelectQueryOps[
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
-    fMonad: Monad[F],
+    fMonad: FutureMonad[F],
     adapter: GuavaAdapter[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedSelectBlock[Table, Record, Limit, Rev]] = {

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
@@ -17,6 +17,7 @@ package com.outworkers.phantom.builder.query.prepared
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import com.outworkers.phantom.ScalaFutureImplicits._
 import com.outworkers.phantom.builder.query.execution.ExactlyOncePromise
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/builder/query/prepared/ExactlyOncePromiseTests.scala
@@ -17,7 +17,6 @@ package com.outworkers.phantom.builder.query.prepared
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.outworkers.phantom.ScalaFutureImplicits._
 import com.outworkers.phantom.builder.query.execution.ExactlyOncePromise
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
@@ -53,7 +53,7 @@ object TwitterPromiseInterface extends PromiseInterface[Promise, Future] {
 
   override def future[T](source: Promise[T]): Future[T] = source
 
-  override def failed[T](exception: Exception): Future[T] = Future.exception[T](exception)
+  override def failed[T](exception: Throwable): Future[T] = Future.exception[T](exception)
 
   override def apply[T](value: T): Future[T] = Future.value(value)
 }

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
@@ -15,30 +15,25 @@
  */
 package com.outworkers.phantom.finagle.execution
 
-import cats.Monad
-import com.outworkers.phantom.builder.query.execution.PromiseInterface
+import com.outworkers.phantom.builder.query.execution.{FutureMonad, PromiseInterface}
 import com.outworkers.phantom.ops.QueryContext
 import com.twitter.conversions.time._
 import com.twitter.util.{Await, Duration, Future, Promise}
 
+import scala.concurrent.ExecutionContextExecutor
+
 object TwitterFutureImplicits {
 
-  val monadInstance: Monad[Future] = new Monad[Future] {
+  val monadInstance: FutureMonad[Future] = new FutureMonad[Future] {
+    override def flatMap[A, B](fa: Future[A])(f: (A) => Future[B])(
+      implicit ctx: ExecutionContextExecutor
+    ): Future[B] = fa flatMap f
 
-    override def flatMap[A, B](fa: Future[A])(f: (A) => Future[B]): Future[B] = fa flatMap f
+    override def map[A, B](source: Future[A])(f: (A) => B)(
+      implicit ctx: ExecutionContextExecutor
+    ): Future[B] = source map f
 
-    /**
-      * Note that while this implementation will not compile with `@tailrec`,
-      * it is in fact stack-safe.
-      */
-    final def tailRecM[B, C](b: B)(f: B => Future[Either[B, C]]): Future[C] = {
-      f(b).flatMap {
-        case Left(b1) => tailRecM(b1)(f)
-        case Right(c) => Future.value(c)
-      }
-    }
-
-    override def pure[A](x: A): Future[A] = Future.value(x)
+    override def pure[A](source: A): Future[A] = Future.value(source)
   }
 
 }

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
@@ -15,7 +15,6 @@
  */
 package com.outworkers.phantom
 
-import cats.Monad
 import com.datastax.driver.core.Statement
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.query._
@@ -32,11 +31,11 @@ import org.joda.time.Seconds
 import shapeless.HList
 
 import scala.collection.generic.CanBuildFrom
-import scala.concurrent.{ExecutionContextExecutor}
+import scala.concurrent.ExecutionContextExecutor
 
 package object finagle extends TwitterQueryContext with DefaultImports {
 
-  implicit val twitterFutureMonad: Monad[Future] = TwitterFutureImplicits.monadInstance
+  implicit val twitterFutureMonad: FutureMonad[Future] = TwitterFutureImplicits.monadInstance
 
   /**
     * Method that allows executing a simple query straight from text, by-passing the entire mapping layer

--- a/phantom-streams/src/test/scala/com/outworkers/phantom/streams/suites/iteratee/IteratorTest.scala
+++ b/phantom-streams/src/test/scala/com/outworkers/phantom/streams/suites/iteratee/IteratorTest.scala
@@ -40,11 +40,9 @@ class IteratorTest extends BigTest with ScalaFutures {
       iterator <- database.timeuuidTable.select.where(_.user eqs user).iterator()
     } yield iterator
 
-    whenReady(chain) {
-      res => {
-        res.records.size shouldEqual generationSize
-        res.records.forall(rows contains _)
-      }
+    whenReady(chain) { res =>
+      res.records.size shouldEqual generationSize
+      res.records.forall(rows contains _)
     }
   }
 
@@ -71,7 +69,6 @@ class IteratorTest extends BigTest with ScalaFutures {
     } yield (count, firstHalf, secondHalf)
 
     whenReady(chain) { case (count, firstBatch, secondBatch) =>
-
       count shouldBe defined
       count.value shouldEqual generationSize
 


### PR DESCRIPTION
- Removing `cats` library dependency from `build.sbt`.
- Replaced `cats.Monad` and monad operations with very simple home baked solution.
- Replaced dependency on fixed `ExecutionContext` required by cats.
