### PR TITLE
Correcting method invoked on createAsync.

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/DatabaseHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/DatabaseHelper.scala
@@ -71,7 +71,7 @@ class DatabaseHelperMacro(override val c: whitebox.Context) extends WhiteboxTool
 
          def createQueries(db: $tpe)(
            implicit space: $keyspaceType
-         ): $execution.QueryCollection[_root_.scala.collection.Seq] = {
+         ): $execution.QueryCollection[Seq] = {
             new $execution.QueryCollection($seqCmp.apply(..$queryList))
          }
        }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
@@ -17,6 +17,7 @@ package com.outworkers.phantom.macros
 
 import com.outworkers.phantom.builder.query.sasi.Mode
 import com.outworkers.phantom.column.AbstractColumn
+import com.outworkers.phantom.connectors.KeySpace
 import com.outworkers.phantom.keys.SASIIndex
 import com.outworkers.phantom.macros.toolbelt.{HListHelpers, WhiteboxToolbelt}
 import com.outworkers.phantom.{CassandraTable, SelectTable}
@@ -36,13 +37,13 @@ trait RootMacro extends HListHelpers with WhiteboxToolbelt {
   protected[this] val builderPkg = q"_root_.com.outworkers.phantom.builder.query"
   protected[this] val enginePkg = q"_root_.com.outworkers.phantom.builder.query.engine"
   protected[this] val strTpe = tq"_root_.java.lang.String"
-  protected[this] val colType = tq"_root_.com.outworkers.phantom.column.AbstractColumn[_]"
+  protected[this] val colType = typeOf[com.outworkers.phantom.column.AbstractColumn[_]]
   protected[this] val sasiIndexTpe = typeOf[SASIIndex[_ <: Mode]]
   protected[this] val collections = q"_root_.scala.collection.immutable"
   protected[this] val rowTerm = TermName("row")
   protected[this] val tableTerm = TermName("table")
   protected[this] val inputTerm = TermName("input")
-  protected[this] val keyspaceType = tq"_root_.com.outworkers.phantom.connectors.KeySpace"
+  protected[this] val keyspaceType = typeOf[KeySpace]
   protected[this] val nothingTpe: Type = typeOf[scala.Nothing]
 
   val knownList = List("Any", "Object", "RootConnector")

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
@@ -57,7 +57,7 @@ abstract class DbOps[
     * @return A sequence of result sets, where every result is the result of a single create operation.
     */
   def createAsync()(implicit ex: ExecutionContextExecutor): F[Seq[ResultSet]] = {
-    execute(db.autocreate()).future()
+    execute(db.autocreate()).sequence()
   }
 
   /**


### PR DESCRIPTION
- Using `typeOf` of instead of TypeTree.
- Replacing `.create` mechanism with the correct `.sequence` instead of parallel ops.