### PR TITLE
Feature/log4j embedded cassandra

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/CassandraTable.scala
@@ -15,11 +15,10 @@
  */
 package com.outworkers.phantom
 
-import com.datastax.driver.core.Session
 import com.outworkers.phantom.builder.QueryBuilder
 import com.outworkers.phantom.builder.clauses.DeleteClause
 import com.outworkers.phantom.builder.primitives.Primitive
-import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, ExecutableStatements, FutureMonad, GuavaAdapter, QueryCollection}
+import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, QueryCollection}
 import com.outworkers.phantom.builder.query.sasi.Mode
 import com.outworkers.phantom.builder.query.{RootCreateQuery, _}
 import com.outworkers.phantom.column.AbstractColumn
@@ -28,9 +27,6 @@ import com.outworkers.phantom.keys.SASIIndex
 import com.outworkers.phantom.macros.{==:==, SingleGeneric, TableHelper}
 import org.slf4j.{Logger, LoggerFactory}
 import shapeless.{Generic, HList}
-
-import scala.concurrent.ExecutionContextExecutor
-import com.outworkers.phantom.builder.query.execution.FutureMonadOps._
 
 /**
  * Main representation of a Cassandra table.
@@ -56,25 +52,6 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R](
   def instance: T = self.asInstanceOf[T]
 
   lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))
-
-  def generateSchema[F[_]]()(
-    implicit session: Session,
-    keySpace: KeySpace,
-    ec: ExecutionContextExecutor,
-    monad: FutureMonad[F],
-    guavaAdapter: GuavaAdapter[F]
-  ): F[Seq[ResultSet]] = {
-
-    val qb = autocreate(keySpace)
-
-    for {
-      t <- guavaAdapter.fromGuava(qb.executableQuery)
-      secondaries <- new ExecutableStatements[F, Seq](qb.indexList).future()
-      sasies <- new ExecutableStatements[F, Seq](sasiQueries).future()
-    } yield Seq(t) ++ secondaries ++ sasies
-
-    new ExecutableStatements[F, Seq](autocreate(keySpace).queries).sequence()
-  }
 
   def tableName: String = helper.tableName
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CreateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/CreateQuery.scala
@@ -20,7 +20,7 @@ import com.outworkers.phantom.CassandraTable
 import com.outworkers.phantom.builder._
 import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.query.execution.{ExecutableCqlQuery, QueryCollection}
-import com.outworkers.phantom.builder.query.options.TablePropertyClause
+import com.outworkers.phantom.builder.query.options.{CachingStrategies, TablePropertyClause}
 import com.outworkers.phantom.builder.syntax.CQLSyntax
 import com.outworkers.phantom.connectors.{KeySpace, SessionAugmenterImplicits}
 
@@ -161,7 +161,7 @@ object CreateQuery {
 
 private[phantom] trait CreateImplicits extends TablePropertyClauses {
 
-  val Cache = Caching
+  val Cache: CachingStrategies = Caching
 
   def apply[
     T <: CassandraTable[T, _],

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
@@ -47,3 +47,16 @@ trait FutureMonad[F[_]] {
     implicit ctx: ExecutionContextExecutor
   ): F[B]
 }
+
+
+object FutureMonadOps {
+  implicit class Ops[F[_], A](val source: F[A])(implicit monad: FutureMonad[F]) {
+    def map[B](f: A => B)(
+      implicit ctx: ExecutionContextExecutor
+    ): F[B] = monad.map(source)(f)
+
+    def flatMap[B](fn: A => F[B])(
+      implicit ctx: ExecutionContextExecutor
+    ): F[B]= monad.flatMap(source)(fn)
+  }
+}

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
@@ -250,20 +250,12 @@ abstract class QueryContext[P[_], F[_], Timeout](
 
   implicit class CassandraTableStoreMethods[T <: CassandraTable[T, R], R](val table: CassandraTable[T, R]) {
 
-    def createSchemaAsync()(
-      implicit session: Session,
-      keySpace: KeySpace,
-      ec: ExecutionContextExecutor
-    ): F[Seq[ResultSet]] = {
-      new ExecutableStatements[F, Seq](table.autocreate(keySpace).queries).sequence()
-    }
-
     def createSchema(timeout: Timeout = defaultTimeout)(
       implicit session: Session,
       keySpace: KeySpace,
       ec: ExecutionContextExecutor
     ): Seq[ResultSet] = {
-      await(new ExecutableStatements[F, Seq](table.autocreate(keySpace).queries).sequence(), timeout)
+      await(table.autocreate(keySpace).future(), timeout)
     }
 
     def storeRecord[V1, Repr <: HList, HL <: HList, Out <: HList](input: V1)(

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/QueryContext.scala
@@ -239,7 +239,13 @@ abstract class QueryContext[P[_], F[_], Timeout](
     override def future()(
       implicit session: Session,
       ctx: ExecutionContextExecutor
-    ): F[Seq[ResultSet]] = new ExecutableStatements[F, Seq](query.queries).sequence()
+    ): F[Seq[ResultSet]] = {
+      for {
+        tableCreationQuery <- adapter.fromGuava(query.executableQuery)
+        secondaryIndexes <- new ExecutableStatements(query.indexList).future()
+        sasiIndexes <- new ExecutableStatements(query.table.sasiQueries()).future()
+      } yield Seq(tableCreationQuery) ++ secondaryIndexes ++ sasiIndexes
+    }
   }
 
   implicit class CassandraTableStoreMethods[T <: CassandraTable[T, R], R](val table: CassandraTable[T, R]) {

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
@@ -66,7 +66,7 @@ package object finagle extends TwitterQueryContext with DefaultImports {
   implicit class SpoolSelectQueryOps[
     P[_],
     F[_],
-    Table <: CassandraTable[Table, _],
+    T <: CassandraTable[T, _],
     Record,
     Limit <: LimitBound,
     Order <: OrderBound,
@@ -74,7 +74,7 @@ package object finagle extends TwitterQueryContext with DefaultImports {
     Chain <: WhereBound,
     PS <: HList
   ](
-    val query: SelectQuery[Table, Record, Limit, Order, Status, Chain, PS]
+    val query: SelectQuery[T, Record, Limit, Order, Status, Chain, PS]
   ) extends AnyVal {
     /**
       * Produces a Twitter Spool of [R]ows
@@ -148,34 +148,34 @@ package object finagle extends TwitterQueryContext with DefaultImports {
   }
 
   implicit class InsertQueryAugmenter[
-    Table <: CassandraTable[Table, Record],
+    T <: CassandraTable[T, Record],
     Record,
     Status <: ConsistencyBound,
     PS <: HList
 
-  ](val query: InsertQuery[Table, Record, Status, PS]) extends AnyVal {
-    def ttl(duration: com.twitter.util.Duration): InsertQuery[Table, Record, Status, PS] = {
+  ](val query: InsertQuery[T, Record, Status, PS]) extends AnyVal {
+    def ttl(duration: com.twitter.util.Duration): InsertQuery[T, Record, Status, PS] = {
       query.ttl(duration.inSeconds)
     }
   }
 
   implicit class UpdateQueryAugmenter[
-    Table <: CassandraTable[Table, _],
+    T <: CassandraTable[T, _],
     Record,
     Limit <: LimitBound,
     Order <: OrderBound,
     Status <: ConsistencyBound,
     Chain <: WhereBound,
     PS <: HList
-  ](val query: UpdateQuery[Table, Record, Limit, Order, Status, Chain, PS]) extends AnyVal {
+  ](val query: UpdateQuery[T, Record, Limit, Order, Status, Chain, PS]) extends AnyVal {
 
-    def ttl(duration: com.twitter.util.Duration): UpdateQuery[Table, Record, Limit, Order, Status, Chain, PS] = {
+    def ttl(duration: com.twitter.util.Duration): UpdateQuery[T, Record, Limit, Order, Status, Chain, PS] = {
       query.ttl(duration.inSeconds)
     }
   }
 
   implicit class AssignmentsUpdateQueryAugmenter[
-    Table <: CassandraTable[Table, _],
+    T <: CassandraTable[T, _],
     Record,
     Limit <: LimitBound,
     Order <: OrderBound,
@@ -183,15 +183,15 @@ package object finagle extends TwitterQueryContext with DefaultImports {
     Chain <: WhereBound,
     PS <: HList,
     ModifiedPrepared <: HList
-  ](val query: AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared]) extends AnyVal {
+  ](val query: AssignmentsQuery[T, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared]) extends AnyVal {
 
-    def ttl(duration: TwitterDuration): AssignmentsQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared] = {
+    def ttl(duration: TwitterDuration): AssignmentsQuery[T, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared] = {
       query.ttl(duration.inSeconds)
     }
   }
 
   implicit class ConditionalUpdateQueryAugmenter[
-    Table <: CassandraTable[Table, _],
+    T <: CassandraTable[T, _],
     Record,
     Limit <: LimitBound,
     Order <: OrderBound,
@@ -199,9 +199,9 @@ package object finagle extends TwitterQueryContext with DefaultImports {
     Chain <: WhereBound,
     PS <: HList,
     ModifiedPrepared <: HList
-  ](val query: ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared]) extends AnyVal {
+  ](val query: ConditionalQuery[T, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared]) extends AnyVal {
 
-    def ttl(duration: TwitterDuration): ConditionalQuery[Table, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared] = {
+    def ttl(duration: TwitterDuration): ConditionalQuery[T, Record, Limit, Order, Status, Chain, PS, ModifiedPrepared] = {
       query.ttl(duration.inSeconds)
     }
   }

--- a/phantom-sbt/src/main/resources/log4j.properties
+++ b/phantom-sbt/src/main/resources/log4j.properties
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# for production, you should probably set the root to INFO
+# and the pattern to %c instead of %l.  (%l is slower.)
+
+# output messages into a rolling log file as well as stdout
+log4j.rootLogger=ERROR,stdout,HColumnFamilyLogger
+
+# stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c{3} - %m%n
+log4j.appender.stdout.follow=true
+
+log4j.appender.HColumnFamilyLogger=org.apache.log4j.ConsoleAppender
+log4j.appender.HColumnFamilyLogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.HColumnFamilyLogger.layout.ConversionPattern=%m%n
+log4j.category.HColumnFamilyLogger=ERROR
+#log4j.category.org.apache=INFO, stdout

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -23,7 +23,7 @@ import scala.util.Properties
 object Publishing {
 
   val defaultPublishingSettings = Seq(
-    version := "2.14.5"
+    version := "2.15.0"
   )
 
   lazy val noPublishSettings = Seq(


### PR DESCRIPTION
- Using `flatMap` instead of `zipWith` and `sequence` semantics to run create queries in parallel.
- Adding a standard logging configuration set to `ERROR` for Embedded Cassandra.