### PR TITLE
Skip generating cql for columns that eval to null

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -96,10 +96,15 @@ case class InsertQuery[
     col: Table => AbstractColumn[RR],
     value: RR
   )(): InsertQuery[Table, Record, Status, PS] = {
-    copy(
-      columnsPart = columnsPart append CQLQuery(col(table).name),
-      valuePart = valuePart append CQLQuery(col(table).asCql(value))
-    )
+    val cql = col(table).asCql(value)
+    if (cql == null) {
+      this
+    } else {
+      copy(
+        columnsPart = columnsPart append CQLQuery(col(table).name),
+        valuePart = valuePart append CQLQuery(cql)
+      )
+    }
   }
 
   final def p_value[RR](

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -98,12 +98,12 @@ case class InsertQuery[
   )(): InsertQuery[Table, Record, Status, PS] = {
     val cql = col(table).asCql(value)
     if (Option(cql).isDefined) {
-      this
-    } else {
       copy(
         columnsPart = columnsPart append CQLQuery(col(table).name),
         valuePart = valuePart append CQLQuery(cql)
       )
+    } else {
+      this
     }
   }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -97,7 +97,7 @@ case class InsertQuery[
     value: RR
   )(): InsertQuery[Table, Record, Status, PS] = {
     val cql = col(table).asCql(value)
-    if (cql == null) {
+    if (Option(cql).isDefined) {
       this
     } else {
       copy(


### PR DESCRIPTION
If a column evaluates to null, inserting causes a tombstone to be
inserted for that column. Therefore we skip inserting columns with null
values.