### PR TITLE
Skip inserts for cql that evals to null (pt 2)

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -86,7 +86,11 @@ case class InsertQuery[
 
   def values[RR](insertions: (CQLQuery, CQLQuery)*): InsertQuery[Table, Record, Status, PS] = {
     val (appendedCols, appendedVals) = (insertions :\ columnsPart -> valuePart) {
-      case ((columnRef, valueRef), (cols, vals)) => Tuple2(cols append columnRef, vals append valueRef)
+      case ((columnRef, valueRef), cvs@(cols, vals)) =>
+        Option(valueRef.toString) match {
+          case Some(_) => Tuple2(cols append columnRef, vals append valueRef)
+          case None    => cvs
+        }
     }
 
     copy(columnsPart = appendedCols, valuePart = appendedVals)


### PR DESCRIPTION
pr #759 omitted the values method. This rectifies that oversight