### PR TITLE
Propagating Scala version to trigger coveralls via .yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_cache:
 
 env:
   global:
+  - TRIGGER_SCALA_VERSION: "2.12.4"
   - GH_REF: github.com/outworkers/phantom.git
   - secure: WwLG0fkVV1DS5P6GeLOHjPJ2z+GP9UaLzX27DuHBEXRxNPPw27y7jag0gbbf6E80kYwGB4zfBx9YjcJFVFdGCCcAjDJHMP8kLQirUak1jzuoWZFUEtTkF7ev/OVs0PmMHrOGuysT4W/UaL9MZD/mYO5lO9oavycTQ0kbOwZJwUg=
   - secure: Qtr5ULJ90s5pfLBaXRKFLMPBcDSYBQfUVz+abgjlG/um8iWE/OJswYn2n3zylAqnI4bSKhPobl6bBYzt8f6k9kzMqpR4t/4gWFV1LJUas0eAsTnrjV1He4nbPvO9RVEkvuQcTCqmus2AgYEnwdKhGWwktok5PAoJ22ycy4HK8C8=

--- a/build/publish_develop.sh
+++ b/build/publish_develop.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
 echo "Pull request: ${TRAVIS_PULL_REQUEST}; Branch: ${TRAVIS_BRANCH}"
-TARGET_SCALA_VERSION="2.12.4"
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "develop" ];
 then
-    if [ "${TRAVIS_SCALA_VERSION}" == "${TARGET_SCALA_VERSION}" ] && [ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" ];
+    if [ "${TRAVIS_SCALA_VERSION}" == "${TRIGGER_SCALA_VERSION}" ] && [ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" ];
     then
 
         echo "Setting git user email to ci@outworkers.com"
@@ -117,7 +116,7 @@ then
         fi
 
     else
-        echo "Only publishing version for Scala $TARGET_SCALA_VERSION and Oracle JDK 8 to prevent multiple artifacts"
+        echo "Only publishing version for Scala $TRIGGER_SCALA_VERSION and Oracle JDK 8 to prevent multiple artifacts"
     fi
 else
     echo "This is either a pull request or the branch is not develop, deployment not necessary"

--- a/build/run_tests.sh
+++ b/build/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 function run_test_suite {
-    if [ "${TRAVIS_SCALA_VERSION}" == "2.12.3" ] && [ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" ];
+    if [ "${TRAVIS_SCALA_VERSION}" == "${TRIGGER_SCALA_VERSION}" ] && [ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" ];
     then
         echo "Running tests with coverage and report submission"
         sbt ++$TRAVIS_SCALA_VERSION coverage test coverageReport coverageAggregate coveralls


### PR DESCRIPTION
- Adding trigger Scala version to `.travis.yml` to prevent mismatches.