### PR TITLE
[phantom-jdk8] DateTime columns, use timestamp instead of long

### DIFF
--- a/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/indexed/package.scala
+++ b/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/indexed/package.scala
@@ -24,11 +24,10 @@ import org.joda.time.{DateTime, DateTimeZone}
 
 package object indexed {
 
-  implicit val OffsetDateTimeIsPrimitive: Primitive[OffsetDateTime] = {
-    Primitive.derive[OffsetDateTime, Long](_.toInstant.toEpochMilli) { timestamp =>
-      OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC)
-    }
-  }
+  implicit val OffsetDateTimeIsPrimitive: Primitive[OffsetDateTime] = Primitive.manuallyDerive[OffsetDateTime, Long](
+    _.toInstant.toEpochMilli,
+    millis => OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC)
+  )(Primitives.LongPrimitive)(CQLSyntax.Types.Timestamp)
 
   implicit val zonePrimitive: Primitive[ZoneId] = Primitive.derive[ZoneId, String](_.getId)(ZoneId.of)
 
@@ -43,11 +42,10 @@ package object indexed {
 
   )(Primitives.LocalDateIsPrimitive)(CQLSyntax.Types.Date)
 
-  implicit val zonedDateTimePrimitive: Primitive[ZonedDateTime] = {
-    Primitive.derive[ZonedDateTime, Long](_.toInstant.toEpochMilli) {
-      ts => ZonedDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneOffset.UTC)
-    }
-  }
+  implicit val zonedDateTimePrimitive: Primitive[ZonedDateTime] = Primitive.manuallyDerive[ZonedDateTime, Long](
+    _.toInstant.toEpochMilli,
+    ts => ZonedDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneOffset.UTC)
+  )(Primitives.LongPrimitive)(CQLSyntax.Types.Timestamp)
 
   implicit val JdkLocalDateTimeIsPrimitive: Primitive[JavaLocalDateTime] = {
     Primitive.derive[JavaLocalDateTime, DateTime](jd =>

--- a/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/package.scala
+++ b/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/package.scala
@@ -35,11 +35,20 @@ package object jdk8 {
   type JdkLocalDateTime = java.time.LocalDateTime
 
   implicit val OffsetDateTimeIsPrimitive: Primitive[OffsetDateTime] = {
-    Primitive.derive[OffsetDateTime, (Long, String)](
-      offsetDt => offsetDt.toInstant.toEpochMilli -> offsetDt.getOffset.getId
-    ) { case (timestamp, zone) =>
-      OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.of(zone))
-    }
+    val tuplePremitive = implicitly[Primitive[(Long, String)]]
+    Primitive.manuallyDerive[OffsetDateTime, (Long, String)](
+      offsetDt => offsetDt.toInstant.toEpochMilli -> offsetDt.getOffset.getId,
+      {
+        case (timestamp, zone) => OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.of(zone))
+      }
+    )(tuplePremitive)(
+      CQLSyntax.Collections.tuple +
+        CQLSyntax.Symbols.`<` +
+        CQLSyntax.Types.Timestamp +
+        CQLSyntax.Symbols.`,` +
+        CQLSyntax.Types.Text +
+        CQLSyntax.Symbols.`>`
+    )
   }
 
   implicit val zonePrimitive: Primitive[ZoneId] = Primitive.derive[ZoneId, String](_.getId)(ZoneId.of)
@@ -56,9 +65,20 @@ package object jdk8 {
   )(Primitives.LocalDateIsPrimitive)(CQLSyntax.Types.Date)
 
   implicit val zonedDateTimePrimitive: Primitive[ZonedDateTime] = {
-    Primitive.derive[ZonedDateTime, (Long, String)](dt => dt.toInstant.toEpochMilli -> dt.getZone.getId) {
-      case (timestamp, zone) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.of(zone))
-    }
+    val tuplePremitive = implicitly[Primitive[(Long, String)]]
+    Primitive.manuallyDerive[ZonedDateTime, (Long, String)](
+      dt => dt.toInstant.toEpochMilli -> dt.getZone.getId,
+      {
+        case (timestamp, zone) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.of(zone))
+      }
+    )(tuplePremitive)(
+      CQLSyntax.Collections.tuple +
+        CQLSyntax.Symbols.`<` +
+        CQLSyntax.Types.Timestamp +
+        CQLSyntax.Symbols.`,` +
+        CQLSyntax.Types.Text +
+        CQLSyntax.Symbols.`>`
+    )
   }
 
   implicit val JdkLocalDateTimeIsPrimitive: Primitive[JavaLocalDateTime] = {

--- a/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/package.scala
+++ b/phantom-jdk8/src/main/scala/com/outworkers/phantom/jdk8/package.scala
@@ -25,6 +25,7 @@ import java.time.{LocalDate => JavaLocalDate, LocalDateTime => JavaLocalDateTime
 import com.datastax.driver.core.{LocalDate => DatastaxLocalDate}
 import com.outworkers.phantom.builder.primitives.{Primitive, Primitives}
 import com.outworkers.phantom.builder.syntax.CQLSyntax
+import com.outworkers.phantom.builder.QueryBuilder
 import org.joda.time.{DateTime, DateTimeZone}
 
 package object jdk8 {
@@ -42,12 +43,7 @@ package object jdk8 {
         case (timestamp, zone) => OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.of(zone))
       }
     )(tuplePremitive)(
-      CQLSyntax.Collections.tuple +
-        CQLSyntax.Symbols.`<` +
-        CQLSyntax.Types.Timestamp +
-        CQLSyntax.Symbols.`,` +
-        CQLSyntax.Types.Text +
-        CQLSyntax.Symbols.`>`
+      QueryBuilder.Collections.tupleType(CQLSyntax.Types.Timestamp, CQLSyntax.Types.Text).queryString
     )
   }
 
@@ -72,12 +68,7 @@ package object jdk8 {
         case (timestamp, zone) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.of(zone))
       }
     )(tuplePremitive)(
-      CQLSyntax.Collections.tuple +
-        CQLSyntax.Symbols.`<` +
-        CQLSyntax.Types.Timestamp +
-        CQLSyntax.Symbols.`,` +
-        CQLSyntax.Types.Text +
-        CQLSyntax.Symbols.`>`
+      QueryBuilder.Collections.tupleType(CQLSyntax.Types.Timestamp, CQLSyntax.Types.Text).queryString
     )
   }
 


### PR DESCRIPTION
fix #817

### describe

If create a column of OffsetDateTime / ZonedDateTime using phantom-jdk8, a Long column is created in Cassandra.
It differs from the document description.
Timestamp column should be created.

Document: https://github.com/outworkers/phantom/blame/ee739e9d135469255e7ec63f47ad5f45fd3fa219/docs/basics/primitives.md#L301-L322

### note
I did not know how to get Tuple's Primiteve.
So the code I wrote is not optimal.
I want to know a good way.

There is no test, so it may be better to write.

### cqlsh results
before

```sql
cqlsh> DESCRIBE phantom.primitivesjdk8 ;

CREATE TABLE phantom.primitivesjdk8 (
    pkey text PRIMARY KEY,
    localdate date,
    localdatetime timestamp,
    offsetdatetime frozen<tuple<long, text>>,
    zoneddatetime frozen<tuple<long, text>>
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND speculative_retry = '99PERCENTILE';
```
after
```sql
cqlsh> DESCRIBE phantom.primitivesjdk8 ;

CREATE TABLE phantom.primitivesjdk8 (
    pkey text PRIMARY KEY,
    localdate date,
    localdatetime timestamp,
    offsetdatetime frozen<tuple<timestamp, text>>,
    zoneddatetime frozen<tuple<timestamp, text>>
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND speculative_retry = '99PERCENTILE';
```