### PR TITLE
Hotfix/insert method conflict

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/RootMacro.scala
@@ -289,7 +289,7 @@ trait RootMacro extends HListHelpers with WhiteboxToolbelt {
 
         info(s"Inferred store input type: ${printType(sTpe)} for ${printType(tableTpe)}")
 
-        val tree = q"""$tableTerm.insert.values(..$finalDefinitions)"""
+        val tree = q"""$tableTerm.`insertValues`(..$finalDefinitions)"""
         Some(tree)
       } else {
         None

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/macros/TableHelper.scala
@@ -234,7 +234,7 @@ class TableHelperMacro(override val c: whitebox.Context) extends WhiteboxToolbel
 
   /**
     * This works by recursively parsing a list of fields extracted here as record members.
-    * The algorithm will take every fiel from the record and:
+    * The algorithm will take every field from the record and:
     * - If there are record fields to address left, we will search within the available columns
     * for a type that either matches or can be implicitly converted to the record type.
     * - If a single match is found, we declare that as a match, without comparing the field names.

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/bugs/ClientKeys.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/bugs/ClientKeys.scala
@@ -16,7 +16,6 @@
 package com.outworkers.phantom.tables.bugs
 
 import com.outworkers.phantom.dsl._
-
 import scala.concurrent.Future
 
 case class ClientKey(sessionId: UUID, key: String, other: String)
@@ -33,4 +32,5 @@ abstract class ClientKeys extends Table[ClientKeys, ClientKey] {
   def insert(c: ClientKey): Future[ResultSet] = {
     insert().future()
   }
+
 }

--- a/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/bugs/ClientKeys.scala
+++ b/phantom-dsl/src/test/scala/com/outworkers/phantom/tables/bugs/ClientKeys.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 - 2017 Outworkers Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.outworkers.phantom.tables.bugs
+
+import com.outworkers.phantom.dsl._
+
+import scala.concurrent.Future
+
+case class ClientKey(sessionId: UUID, key: String, other: String)
+
+abstract class ClientKeys extends Table[ClientKeys, ClientKey] {
+  object sessionId extends UUIDColumn with PartitionKey
+  object key extends StringColumn with ClusteringOrder
+  object other extends StringColumn
+
+  def findById(id: UUID): Future[Option[ClientKey]] = {
+    select.where(_.sessionId eqs id).one()
+  }
+
+  def insert(c: ClientKey): Future[ResultSet] = {
+    insert().future()
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.25.0-SNAPSHOT"
+version in ThisBuild := "2.25.0"


### PR DESCRIPTION
- Preventing `TableHelper` naming conflict by using quotes in method names.