### PR TITLE
Feature/list prepared ops

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,9 +169,8 @@ lazy val Versions = new {
   }
 }
 
-
 val releaseSettings = Seq(
-  releaseTutFolder in ThisBuild := baseDirectory.value / "docs",
+  releaseTutFolder := baseDirectory.value / "docs",
   releaseIgnoreUntrackedFiles := true,
   releaseVersionBump := sbtrelease.Version.Bump.Minor,
   releaseTagComment := s"Releasing ${(version in ThisBuild).value} $ciSkipSequence",
@@ -179,10 +178,9 @@ val releaseSettings = Seq(
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
-    setReleaseVersion,
-    commitReleaseVersion,
     releaseStepTask((tut in Tut) in readme),
-    commitTutFiles,
+    setReleaseVersion,
+    commitTutFilesAndVersion,
     releaseStepCommandAndRemaining("such publishSigned"),
     releaseStepCommandAndRemaining("sonatypeReleaseAll"),
     tagRelease,
@@ -226,7 +224,7 @@ val sharedSettings: Seq[Def.Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
   ),
   envVars := Map("SCALACTIC_FILL_FILE_PATHNAMES" -> "yes"),
   parallelExecution in ThisBuild := false
-) ++ Publishing.effectiveSettings
+) ++ Publishing.effectiveSettings ++ releaseSettings
 
 lazy val baseProjectList: Seq[ProjectReference] = Seq(
   phantomDsl,
@@ -255,7 +253,8 @@ lazy val phantom = (project in file("."))
       "coverageAggregate" ::
       "coveralls" ::
       state
-    }
+    },
+    commands += testCommitsForDocs
   ).aggregate(
     fullProjectList: _*
   )

--- a/build.sbt
+++ b/build.sbt
@@ -245,16 +245,7 @@ lazy val phantom = (project in file("."))
     sharedSettings ++ Publishing.noPublishSettings
   ).settings(
     name := "phantom",
-    moduleName := "phantom",
-    commands += Command.command("testsWithCoverage") { state =>
-      "coverage" ::
-      "test" ::
-      "coverageReport" ::
-      "coverageAggregate" ::
-      "coveralls" ::
-      state
-    },
-    commands += testCommitsForDocs
+    moduleName := "phantom"
   ).aggregate(
     fullProjectList: _*
   )

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Publishing.{ciSkipSequence, commitTutFiles, releaseTutFolder}
+import Publishing.{ciSkipSequence, releaseTutFolder}
 import sbt.Keys._
 import sbt._
 import sbtrelease.ReleaseStateTransformations._

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,7 @@ val releaseSettings = Seq(
     inquireVersions,
     releaseStepTask((tut in Tut) in readme),
     setReleaseVersion,
-    commitTutFilesAndVersion,
+    Publishing.commitTutFilesAndVersion,
     releaseStepCommandAndRemaining("such publishSigned"),
     releaseStepCommandAndRemaining("sonatypeReleaseAll"),
     tagRelease,

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
@@ -332,7 +332,7 @@ trait DefaultImports extends ImplicitMechanism
 
     /**
       * Added to keep the API consistent. It is not possible to add single elements to a set
-      * in Cassandra, the only CQL level support for for collections, even if they are collections
+      * in Cassandra, the only CQL level support is for collections, even if they are collections
       * of a single element. This is a nicety added by the phantom API, and we do a prepared variant
       * to match with the above.
       *
@@ -364,8 +364,8 @@ trait DefaultImports extends ImplicitMechanism
     }
 
     /**
-      * Added to keep the API consistent. It is not possible to remove single elements to a set
-      * in Cassandra, the only CQL level support for for collections, even if they are collections
+      * Added to keep the API consistent. It is not possible to remove single elements from a set
+      * in Cassandra, the only CQL level support is for collections, even if they are collections
       * of a single element. This is a nicety added by the phantom API, and we do a prepared variant
       * to match with the above.
       *

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
@@ -277,7 +277,7 @@ trait DefaultImports extends ImplicitMechanism
       new UpdateClause.Condition(QueryBuilder.Collections.append(col.name, col.asCql(values)))
     }
 
-    def append(mark: PrepareMark): UpdateClause.Default = {
+    def append(mark: PrepareMark): UpdateClause.Prepared[List[RR]] = {
       new UpdateClause.Condition(QueryBuilder.Collections.append(col.name, mark))
     }
 
@@ -289,7 +289,7 @@ trait DefaultImports extends ImplicitMechanism
       new UpdateClause.Condition(QueryBuilder.Collections.discard(col.name, col.asCql(values)))
     }
 
-    def discard(mark: PrepareMark): UpdateClause.Default = {
+    def discard(mark: PrepareMark): UpdateClause.Prepared[List[RR]] = {
       new UpdateClause.Condition(QueryBuilder.Collections.discard(col.name, mark.qb.queryString))
     }
 
@@ -297,8 +297,18 @@ trait DefaultImports extends ImplicitMechanism
       new UpdateClause.Condition(QueryBuilder.Collections.setIdX(col.name, i.toString, col.valueAsCql(value)))
     }
 
-    def setIdx(i: Int, mark: PrepareMark): UpdateClause.Default = {
+    def setIdx(i: Int, mark: PrepareMark): UpdateClause.Prepared[RR] = {
       new UpdateClause.Condition(QueryBuilder.Collections.setIdX(col.name, i.toString, mark.qb.queryString))
+    }
+
+    def setIdx(index: PrepareMark, mark: PrepareMark): UpdateClause.Condition[RR :: Int :: HNil] = {
+      new UpdateClause.Condition(
+        QueryBuilder.Collections.setIdX(
+          col.name,
+          index.qb.queryString,
+          mark.qb.queryString
+        )
+      )
     }
   }
 

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import bintray.BintrayKeys.{bintrayOrganization, bintrayReleaseOnPublish, bintrayRepository}
 import sbt.Keys._
 import sbt._
 import com.typesafe.sbt.pgp.PgpKeys._
@@ -162,7 +163,27 @@ object Publishing {
   )
 
 
-  def effectiveSettings: Seq[Def.Setting[_]] = mavenSettings
+  lazy val bintraySettings: Seq[Def.Setting[_]] = Seq(
+    publishMavenStyle := true,
+    bintrayOrganization := Some("outworkers"),
+    bintrayRepository := {
+      if (scalaVersion.value.trim.endsWith("SNAPSHOT")) {
+        "oss-snapshots"
+      } else {
+        "oss-releases"
+      }
+    },
+    bintrayReleaseOnPublish in ThisBuild := true,
+    publishArtifact in Test := false,
+    publishArtifact in (Compile, packageSrc) := false,
+    publishArtifact in (Test, packageSrc) := false,
+    pomIncludeRepository := { _ => true},
+    publishArtifact in Test := false,
+    licenses += ("Apache-2.0", url("https://github.com/outworkers/phantom/blob/develop/LICENSE.txt"))
+  )
+
+
+  def effectiveSettings: Seq[Def.Setting[_]] = bintraySettings
 
   def runningUnderCi: Boolean = sys.env.get("CI").isDefined || sys.env.get("TRAVIS").isDefined
   def travisScala211: Boolean = sys.env.get("TRAVIS_SCALA_VERSION").exists(_.contains("2.11"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.34.4-SNAPSHOT"
+version in ThisBuild := "2.34.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.34.1"
+version in ThisBuild := "2.34.4-SNAPSHOT"


### PR DESCRIPTION
- Separating out `CollectionModifiers` into specialised traits for each collection.
- Adding more detail for methods to make it more obvious where collections are expected to be bound instead of single element types.
- Adding a two prepared variants of `setIdX` on list collections.