### PR TITLE
Changing the type of executors used.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val scoverageSettings = {
     ScoverageKeys.coverageExcludedPackages := "<empty>;com.outworkers.phantom.example.basics.thrift;",
     ScoverageKeys.coverageExcludedFiles := "<empty>;",
     ScoverageKeys.coverageMinimum := 80,
-    ScoverageKeys.coverageFailOnMinimum := true,
+    ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := true
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,18 @@ val scalacOptionsFn: String => Seq[String] = { s =>
   }
 }
 
+lazy val scoverageSettings = {
+  import scoverage.ScoverageKeys
+  Seq(
+    // Semicolon-separated list of regexs matching classes to exclude
+    ScoverageKeys.coverageExcludedPackages := "<empty>;com.outworkers.phantom.example.basics.thrift;",
+    ScoverageKeys.coverageExcludedFiles := "<empty>;",
+    ScoverageKeys.coverageMinimum := 80,
+    ScoverageKeys.coverageFailOnMinimum := true,
+    ScoverageKeys.coverageHighlighting := true
+  )
+}
+
 scalacOptions in ThisBuild ++= scalacOptionsFn(scalaVersion.value)
 
 lazy val Versions = new {
@@ -243,7 +255,7 @@ val releaseSettings = Seq(
     commitNextVersion,
     pushChanges
   )
-)
+) ++ scoverageSettings
 
 Global / scalaVersion := Versions.scala213
 

--- a/docs/src/main/mdoc/basics/database.md
+++ b/docs/src/main/mdoc/basics/database.md
@@ -18,7 +18,7 @@ Being the final level of segregation between the database layer of your applicat
 At the very bottom level, phantom queries require several implicits in scope to execute:
 Fhich Cassandra cluster to target.
 - The `implicit keySpace: KeySpace`, describing which keyspace to target. It's just a `String`, but it's more strongly typed as we don't want `implicit` strings in our code, ever.
-- The `implicit ex: ExecutionContextExecutor`, which is a Java compatible flavour of `scala.concurrent.ExecutionContext` and basically allows users to supply any context of their choosing for executing database queries.
+- The `implicit ex: ExecutionContext`, which is a Java compatible flavour of `scala.concurrent.ExecutionContext` and basically allows users to supply any context of their choosing for executing database queries.
 
 However, from an app or service consumer perspective, when pulling in dependencies or calling a database service, as a developer I do not want to be concerned with providing a `session` or a `keySpace`. Under some circumstances I may want to provide a custom `ExecutionContext` but that's a different story.
 

--- a/docs_bkp/basics/database.md
+++ b/docs_bkp/basics/database.md
@@ -18,7 +18,7 @@ Being the final level of segregation between the database layer of your applicat
 At the very bottom level, phantom queries require several implicits in scope to execute:
 Fhich Cassandra cluster to target.
 - The `implicit keySpace: KeySpace`, describing which keyspace to target. It's just a `String`, but it's more strongly typed as we don't want `implicit` strings in our code, ever.
-- The `implicit ex: ExecutionContextExecutor`, which is a Java compatible flavour of `scala.concurrent.ExecutionContext` and basically allows users to supply any context of their choosing for executing database queries.
+- The `implicit ex: ExecutionContext`, which is a Java compatible flavour of `scala.concurrent.ExecutionContext` and basically allows users to supply any context of their choosing for executing database queries.
 
 However, from an app or service consumer perspective, when pulling in dependencies or calling a database service, as a developer I do not want to be concerned with providing a `session` or a `keySpace`. Under some circumstances I may want to provide a custom `ExecutionContext` but that's a different story.
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/DefaultImports.scala
@@ -34,9 +34,9 @@ import com.outworkers.phantom.column._
 import com.outworkers.phantom.connectors.DefaultVersions
 import com.outworkers.phantom.keys.Indexed
 import org.joda.time.DateTimeZone
-import shapeless.{ HNil, :: }
+import shapeless.{::, HNil}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.Iterable
 
 trait DefaultImports extends ImplicitMechanism
@@ -557,5 +557,5 @@ trait DefaultImports extends ImplicitMechanism
     }
   }
 
-  implicit val context: ExecutionContextExecutor = Manager.scalaExecutor
+  implicit val context: ExecutionContext = Manager.scalaExecutor
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/Manager.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/Manager.scala
@@ -23,7 +23,7 @@ object Manager {
 
   private[this] lazy val taskExecutor = Executors.newCachedThreadPool()
 
-  implicit lazy val scalaExecutor: ExecutionContextExecutor = ExecutionContext.fromExecutor(taskExecutor)
+  implicit lazy val scalaExecutor: ExecutionContext = ExecutionContext.fromExecutor(taskExecutor)
 
   val logger: Logger = LoggerFactory.getLogger("com.outworkers.phantom")
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ScalaQueryContext.scala
@@ -19,18 +19,18 @@ import com.outworkers.phantom.builder.query.execution.{FutureMonad, PromiseInter
 import com.outworkers.phantom.ops.QueryContext
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContextExecutor, Future, Promise}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future, Promise}
 
 object ScalaFutureImplicits {
 
   implicit val monadInstance: FutureMonad[Future] = new FutureMonad[Future] {
 
     override def flatMap[A, B](source: Future[A])(fn: (A) => Future[B])(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Future[B] = source flatMap fn
 
     override def map[A, B](source: Future[A])(f: (A) => B)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Future[B] = source map f
 
     override def pure[A](source: A): Future[A] = Future.successful(source)

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/ops/ImplicitMechanism.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/ops/ImplicitMechanism.scala
@@ -148,7 +148,7 @@ sealed class MapConditionals[T <: CassandraTable[T, R], R, K, V](val col: Abstra
 
 private[phantom] trait ImplicitMechanism extends ModifyMechanism {
 
-  // implicit lazy val context: ExecutionContextExecutor = Manager.scalaExecutor
+  // implicit lazy val context: ExecutionContext = Manager.scalaExecutor
 
   @implicitNotFound(msg = "Compare-and-set queries can only be applied to non indexed primitive columns.")
   implicit final def columnToCasCompareColumn[RR](

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/primitives/Primitive.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/primitives/Primitive.scala
@@ -491,7 +491,7 @@ object Primitive {
           throw new InvalidTypeException(
             "Invalid boolean value, expecting 1 byte but got " + bytes.remaining
           )
-        case _ => bytes.get(bytes.position) != 0
+        case _ => bytes.get(bytes.position()) != 0
       }
     }
   }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/DeleteQuery.scala
@@ -28,8 +28,9 @@ import com.outworkers.phantom.connectors.KeySpace
 import org.joda.time.DateTime
 import shapeless.ops.hlist.{Prepend, Reverse}
 import shapeless.{=:!=, HList, HNil}
+
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 case class DeleteQuery[
   Table <: CassandraTable[Table, _],
@@ -60,7 +61,7 @@ case class DeleteQuery[
 
   def prepareAsync[P[_], F[_], Rev <: HList]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/InsertQuery.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import shapeless.ops.hlist.Reverse
 import shapeless.{::, =:!=, HList, HNil}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration.Duration
 
 case class InsertQuery[
@@ -134,7 +134,7 @@ case class InsertQuery[
 
   def prepareAsync[P[_], F[_], Rev <: HList]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
@@ -282,7 +282,7 @@ class InsertJsonQuery[
 
   def prepareAsync[P[_], F[_], Rev <: HList]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/SelectQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/SelectQuery.scala
@@ -31,7 +31,7 @@ import shapeless.ops.hlist.{Prepend, Reverse, Tupler}
 import shapeless.{::, =:!=, HList, HNil}
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 case class SelectQuery[
   Table <: CassandraTable[Table, _],
@@ -77,7 +77,7 @@ case class SelectQuery[
 
   def prepareAsync[P[_], F[_], Rev <: HList]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],
@@ -223,7 +223,7 @@ private[phantom] class RootSelectBlock[
     implicit keySpace: KeySpace,
     ev: Primitive[String]
   ): SelectQuery.Default[T, String] = {
-    val jsonParser: (Row) => String = row => {
+    val jsonParser: Row => String = row => {
       ev.deserialize(
         row.getBytesUnsafe(CQLSyntax.JSON_EXTRACTOR),
         row.version

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/UpdateQuery.scala
@@ -28,7 +28,7 @@ import org.joda.time.DateTime
 import shapeless.ops.hlist.{Prepend, Reverse}
 import shapeless.{::, =:!=, HList, HNil}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
 import scala.concurrent.duration._
 
@@ -255,7 +255,7 @@ sealed case class AssignmentsQuery[
     TTLAdded <: HList
   ]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, RevWhere],
@@ -391,7 +391,7 @@ sealed case class ConditionalQuery[
     QueryHL <: HList
   ]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     revWhere: Reverse.Aux[PS, RevWhere],

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/FutureMonad.scala
@@ -15,16 +15,16 @@
  */
 package com.outworkers.phantom.builder.query.execution
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.ExecutionContext
 
 /**
   * A special mini monad implementation that allows us not to have to rely on Cats being
   * part of our dependencies as it's really heavy to use for this simple reason.
-  * Cats also requires binding a future monad for Scala futures against a known [[ExecutionContextExecutor]],
+  * Cats also requires binding a future monad for Scala futures against a known [[ExecutionContext]],
   * which unfortunately interferes with one of the core features in phantom, giving users the ability
   * to supply their own execution context whenever they want.
   *
-  * In our implementation, we go against the grain and include the implicit [[ExecutionContextExecutor]] as part
+  * In our implementation, we go against the grain and include the implicit [[ExecutionContext]] as part
   * of the standard method signature for map and flatMap, and this is only because we want to keep enabling users
   * to supply their own context. Certain implementations of Futures will downright ignore this implicit parameter,
   * but it's there for the implementations of Future and Promise that need it, specifically Scala Standard Lib
@@ -40,11 +40,11 @@ trait FutureMonad[F[_]] {
   def pure[A](source: A): F[A]
 
   def map[A, B](source: F[A])(f: A => B)(
-    implicit ctx: ExecutionContextExecutor
+    implicit ctx: ExecutionContext
   ): F[B]
 
   def flatMap[A, B](source: F[A])(fn: A => F[B])(
-    implicit ctx: ExecutionContextExecutor
+    implicit ctx: ExecutionContext
   ): F[B]
 }
 
@@ -52,11 +52,11 @@ trait FutureMonad[F[_]] {
 object FutureMonadOps {
   implicit class Ops[F[_], A](val source: F[A])(implicit monad: FutureMonad[F]) {
     def map[B](f: A => B)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): F[B] = monad.map(source)(f)
 
     def flatMap[B](fn: A => F[B])(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): F[B]= monad.flatMap(source)(fn)
   }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/QueryInterface.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/QueryInterface.scala
@@ -18,14 +18,14 @@ package com.outworkers.phantom.builder.query.execution
 import com.datastax.driver.core.{Session, Statement}
 import com.outworkers.phantom.ResultSet
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.collection.compat._
 
 trait MultiQueryInterface[M[X] <: IterableOnce[X], F[_]] {
 
   def future()(
     implicit session: Session,
-    ctx: ExecutionContextExecutor
+    ctx: ExecutionContext
   ): F[M[ResultSet]]
 
   /**
@@ -43,7 +43,7 @@ trait MultiQueryInterface[M[X] <: IterableOnce[X], F[_]] {
     */
   def future(modifyStatement: Statement => Statement)(
     implicit session: Session,
-    executor: ExecutionContextExecutor
+    executor: ExecutionContext
   ): F[M[ResultSet]]
 }
 
@@ -67,7 +67,7 @@ abstract class QueryInterface[F[_]]()(implicit adapter: GuavaAdapter[F]) {
     */
   def future()(
     implicit session: Session,
-    ec: ExecutionContextExecutor
+    ec: ExecutionContext
   ): F[ResultSet] = {
     adapter.fromGuava(executableQuery)
   }
@@ -87,7 +87,7 @@ abstract class QueryInterface[F[_]]()(implicit adapter: GuavaAdapter[F]) {
     */
   def future(modifyStatement: Statement => Statement)(
     implicit session: Session,
-    executor: ExecutionContextExecutor
+    executor: ExecutionContext
   ): F[ResultSet] = adapter.fromGuava(modifyStatement(executableQuery.statement()))
 }
 

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/package.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/execution/package.scala
@@ -15,23 +15,23 @@
  */
 package com.outworkers.phantom.builder.query
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.ExecutionContext
 
 package object execution {
 
   implicit class FunctorOps[F[_], T](val in: F[T])(implicit fMonad: FutureMonad[F]) {
     def zipWith[O, R](other: F[O])(fn: (T, O) => R)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): F[R] = {
       for (r1 <- in; r2 <- other) yield fn(r1, r2)
     }
 
     def map[A](fn: T => A)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): F[A] = fMonad.map(in)(fn)
 
     def flatMap[A](fn: T => F[A])(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): F[A] = fMonad.flatMap(in)(fn)
   }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -27,7 +27,7 @@ import com.outworkers.phantom.{CassandraTable, Row}
 import shapeless.ops.hlist.Tupler
 import shapeless.{::, Generic, HList, HNil}
 
-import scala.concurrent.{ExecutionContextExecutor, blocking}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, blocking}
 
 private[phantom] trait PrepareMark {
 
@@ -67,7 +67,7 @@ class PreparedFlattener(qb: CQLQuery)(
   }
 
   def async[P[_], F[_]]()(
-    implicit executor: ExecutionContextExecutor,
+    implicit executor: ExecutionContext,
     monad: FutureMonad[F],
     interface: PromiseInterface[P, F]
   ): F[PreparedStatement] = {

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/DbOps.scala
@@ -19,7 +19,7 @@ import com.outworkers.phantom.ResultSet
 import com.outworkers.phantom.builder.query.execution._
 import com.outworkers.phantom.database.Database
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.collection.compat._
 import scala.collection.Seq
 
@@ -48,7 +48,7 @@ abstract class DbOps[
     *                Defaults to [[com.outworkers.phantom.database.Database#defaultTimeout]]
     * @return A sequence of result sets, where every result is the result of a single create operation.
     */
-  def create(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContextExecutor): Seq[Seq[ResultSet]] = {
+  def create(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContext): Seq[Seq[ResultSet]] = {
     await(createAsync(), timeout)
   }
 
@@ -59,7 +59,7 @@ abstract class DbOps[
     * @return A sequence of result sets, where every result is the result of a single create operation.
     */
   def createAsync()(
-    implicit ex: ExecutionContextExecutor
+    implicit ex: ExecutionContext
   ): F[Seq[Seq[ResultSet]]] = {
     ExecutionHelper.sequencedTraverse(tables.map(_.autocreate(db.space).delegate)) { query =>
       QueryContext.create(query)
@@ -72,7 +72,7 @@ abstract class DbOps[
     *
     * @return A sequence of result sets, where every result is the result of a single drop operation.
     */
-  def dropAsync()(implicit ex: ExecutionContextExecutor): F[Seq[ResultSet]] = {
+  def dropAsync()(implicit ex: ExecutionContext): F[Seq[ResultSet]] = {
     execute(db.autodrop()).future()
   }
 
@@ -84,7 +84,7 @@ abstract class DbOps[
     *                Defaults to [[com.outworkers.phantom.database.Database#defaultTimeout]]
     * @return A sequence of result sets, where every result is the result of a single drop operation.
     */
-  def drop(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContextExecutor): Seq[ResultSet] = {
+  def drop(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContext): Seq[ResultSet] = {
     await(dropAsync(), timeout)
   }
 
@@ -96,7 +96,7 @@ abstract class DbOps[
     *                Defaults to [[com.outworkers.phantom.database.Database#defaultTimeout]]
     * @return A sequence of result sets, where every result is the result of a single truncate operation.
     */
-  def truncate(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContextExecutor): Seq[ResultSet] = {
+  def truncate(timeout: Timeout = defaultTimeout)(implicit ex: ExecutionContext): Seq[ResultSet] = {
     await(truncateAsync(), timeout)
   }
 
@@ -106,7 +106,7 @@ abstract class DbOps[
     *
     * @return A sequence of result sets, where every result is the result of a single truncate operation.
     */
-  def truncateAsync()(implicit ex: ExecutionContextExecutor): F[Seq[ResultSet]] = {
+  def truncateAsync()(implicit ex: ExecutionContext): F[Seq[ResultSet]] = {
     execute(db.autotruncate()).future()
   }
 }

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/SelectQueryOps.scala
@@ -25,7 +25,7 @@ import shapeless.ops.hlist.Reverse
 import shapeless.{=:!=, HList, HNil}
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 class SelectQueryOps[
   P[_],
@@ -56,7 +56,7 @@ class SelectQueryOps[
   def one()(
     implicit session: Session,
     ev: Limit =:= Unlimited,
-    ec: ExecutionContextExecutor
+    ec: ExecutionContext
   ): F[Option[Record]] = {
     val enforceLimit = if (query.count) LimitedPart.empty else query.limitedPart append QueryBuilder.limit(1.toString)
     singleFetch(adapter.fromGuava(query.copy(limitedPart = enforceLimit).executableQuery.statement()))
@@ -75,7 +75,7 @@ class SelectQueryOps[
   def aggregate[T]()(
     implicit session: Session,
     ev: Limit =:= Unlimited,
-    ec: ExecutionContextExecutor,
+    ec: ExecutionContext,
     unwrap: Record <:< Tuple1[T]
   ): F[Option[T]] = {
     singleFetch(adapter.fromGuava(query.executableQuery.statement())).map(_.map { case Tuple1(vd: T) => vd })
@@ -92,7 +92,7 @@ class SelectQueryOps[
   def multiAggregate()(
     implicit session: Session,
     ev: Limit =:= Unlimited,
-    ec: ExecutionContextExecutor
+    ec: ExecutionContext
   ): F[Option[Record]] = {
     singleFetch(adapter.fromGuava(query.executableQuery.statement()))
   }
@@ -101,7 +101,7 @@ class SelectQueryOps[
 
   def prepareAsync[Rev <: HList]()(
     implicit session: Session,
-    executor: ExecutionContextExecutor,
+    executor: ExecutionContext,
     keySpace: KeySpace,
     ev: PS =:!= HNil,
     rev: Reverse.Aux[PS, Rev],

--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/UpdateIncompleteQueryOps.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/ops/UpdateIncompleteQueryOps.scala
@@ -21,7 +21,7 @@ import com.outworkers.phantom.builder.query.SetPart
 import com.outworkers.phantom.builder.query.engine.CQLQuery
 import com.outworkers.phantom.builder.query.execution._
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 trait QueryNotExecuted {
   def qb: CQLQuery
@@ -48,7 +48,7 @@ class UpdateIncompleteQueryOps[
     */
   def succeedAnyway()(
     implicit session: Session,
-    ctx: ExecutionContextExecutor
+    ctx: ExecutionContext
   ): F[Either[QueryNotExecuted, ResultSet]] = {
     if (setPart.nonEmpty) {
       fMonad.map(pf.adapter.fromGuava(query))(Right.apply)

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/execution/TwitterQueryContext.scala
@@ -20,17 +20,17 @@ import com.outworkers.phantom.ops.QueryContext
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Duration, Future, Promise}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object TwitterFutureImplicits {
 
   val monadInstance: FutureMonad[Future] = new FutureMonad[Future] {
     override def flatMap[A, B](fa: Future[A])(f: A => Future[B])(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Future[B] = fa flatMap f
 
     override def map[A, B](source: Future[A])(f: A => B)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Future[B] = source map f
 
     override def pure[A](source: A): Future[A] = Future.value(source)

--- a/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
+++ b/phantom-finagle/src/main/scala/com/outworkers/phantom/finagle/package.scala
@@ -28,7 +28,7 @@ import com.twitter.util.{Duration => TwitterDuration, _}
 import org.joda.time.Seconds
 import shapeless.HList
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.collection.compat._
 
 package object finagle extends TwitterQueryContext with DefaultImports {
@@ -217,13 +217,13 @@ package object finagle extends TwitterQueryContext with DefaultImports {
     CS <: CompressionStrategy[CS]
   ](val strategy: CompressionStrategy[CS]) extends AnyVal {
     def chunk_length_kb(unit: StorageUnit): CompressionStrategy[CS] = {
-      strategy.option(CQLSyntax.CompressionOptions.chunk_length_kb, unit.inKilobytes + "KB")
+      strategy.option(CQLSyntax.CompressionOptions.chunk_length_kb, s"${unit.inKilobytes}KB")
     }
   }
 
   implicit class ExecuteQueries[M[X] <: IterableOnce[X]](val qc: QueryCollection[M]) extends AnyVal {
     def executable()(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): ExecutableStatements[Future, M] = new ExecutableStatements[Future, M](qc)
 
     def future()(

--- a/phantom-monix/src/main/scala/com/outworkers/phantom/monix/execution/MonixImplicits.scala
+++ b/phantom-monix/src/main/scala/com/outworkers/phantom/monix/execution/MonixImplicits.scala
@@ -18,7 +18,7 @@ package com.outworkers.phantom.monix.execution
 import com.outworkers.phantom.builder.query.execution.{FutureMonad, PromiseInterface}
 import monix.eval.Task
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.ExecutionContext
 
 object MonixImplicits {
 
@@ -27,11 +27,11 @@ object MonixImplicits {
   implicit val taskMonad: FutureMonad[Task] = new FutureMonad[Task] {
 
     override def flatMap[A, B](source: Task[A])(fn: (A) => Task[B])(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Task[B] = source flatMap fn
 
     override def map[A, B](source: Task[A])(f: (A) => B)(
-      implicit ctx: ExecutionContextExecutor
+      implicit ctx: ExecutionContext
     ): Task[B] = source map f
 
     override def pure[A](source: A): Task[A] = Task.pure(source)

--- a/phantom-streams/src/main/scala/com/outworkers/phantom/streams/package.scala
+++ b/phantom-streams/src/main/scala/com/outworkers/phantom/streams/package.scala
@@ -142,7 +142,7 @@ package object streams {
     def publisher()(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[T] = {
       enumeratorToPublisher(ct.select.all().fetchEnumerator())
     }
@@ -200,7 +200,7 @@ package object streams {
       */
     def fetchEnumerator()(
       implicit session: Session,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         query.future() map { res =>
@@ -219,7 +219,7 @@ package object streams {
       */
     def fetchEnumerator(mod: Statement => Statement)(
       implicit session: Session,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         query.future(mod) map { res =>
@@ -237,7 +237,7 @@ package object streams {
       */
     def publisher()(
       implicit session: Session,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = enumeratorToPublisher(query.fetchEnumerator())
 
     /**
@@ -250,7 +250,7 @@ package object streams {
       */
     def publisher(modifier: Statement => Statement)(
       implicit session: Session,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = {
       enumeratorToPublisher(query.fetchEnumerator(modifier))
     }
@@ -272,7 +272,7 @@ package object streams {
     def fetchEnumerator()(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         block.all().future() map { res =>
@@ -292,7 +292,7 @@ package object streams {
     def fetchEnumerator(modifier: Statement => Statement)(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         block.all().future(modifier) map { res =>
@@ -313,7 +313,7 @@ package object streams {
     def publisher()(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = enumeratorToPublisher(block.fetchEnumerator())
 
     /**
@@ -329,7 +329,7 @@ package object streams {
     def publisher(modifier: Statement => Statement)(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = {
       enumeratorToPublisher(block.fetchEnumerator(modifier))
     }
@@ -352,7 +352,7 @@ package object streams {
     def fetchEnumerator()(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         block.future() map { res =>
@@ -372,7 +372,7 @@ package object streams {
     def fetchEnumerator(modifier: Statement => Statement)(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): PlayEnumerator[R] = {
       PlayEnumerator.flatten {
         block.future(modifier) map { res =>
@@ -393,7 +393,7 @@ package object streams {
     def publisher()(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = enumeratorToPublisher(block.fetchEnumerator())
 
     /**
@@ -409,7 +409,7 @@ package object streams {
     def publisher(modifier: Statement => Statement)(
       implicit session: Session,
       keySpace: KeySpace,
-      ctx: ExecutionContextExecutor
+      ctx: ExecutionContext
     ): Publisher[R] = {
       enumeratorToPublisher(block.fetchEnumerator(modifier))
     }


### PR DESCRIPTION
- Downcast the type of the implicitly requested execution context from `ExecutionContextExecutor` to `ExecutionContext`.
- This is done to allow framework users to override execution contexts at will.