### PR TITLE
Remove empty argument lists from Primitives.{list,set}

### DIFF
--- a/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/primitives/Primitives.scala
+++ b/phantom-dsl/src/main/scala/com/outworkers/phantom/builder/primitives/Primitives.scala
@@ -163,14 +163,14 @@ object Primitives {
     }
   }
 
-  def list[T]()(implicit ev: Primitive[T]): Primitive[List[T]] = {
+  def list[T](implicit ev: Primitive[T]): Primitive[List[T]] = {
     collectionPrimitive[List, T](
       QueryBuilder.Collections.listType(ev.cassandraType).queryString,
       value => QueryBuilder.Collections.serialize(value.map(ev.asCql)).queryString
     )
   }
 
-  def set[T]()(implicit ev: Primitive[T]): Primitive[Set[T]] = {
+  def set[T](implicit ev: Primitive[T]): Primitive[Set[T]] = {
     collectionPrimitive[Set, T](
       QueryBuilder.Collections.setType(ev.cassandraType).queryString,
       value => QueryBuilder.Collections.serialize(value.map(ev.asCql)).queryString


### PR DESCRIPTION
Remove empty argument lists from `Primitives.list` and
`Primitives.set`, as they are not side-effecting. This fixes
an inconsistency between their definitions and their callsites
generated by macro.

Fixes #923 