### PR TITLE
Allow Monix to cancel the request

### DIFF
--- a/phantom-monix/src/main/scala/com/outworkers/phantom/monix/execution/MonixPromiseInterface.scala
+++ b/phantom-monix/src/main/scala/com/outworkers/phantom/monix/execution/MonixPromiseInterface.scala
@@ -52,7 +52,9 @@ class MonixPromiseInterface extends PromiseInterface[Task, Task]{
         }
 
         Futures.addCallback(source, callback, executor.asInstanceOf[ExecutionContextExecutor])
-        Cancelable.empty
+        Cancelable { () =>
+          source.cancel(true)
+        }
       }
     }
 


### PR DESCRIPTION
ResultSetFuture is cancellable (up to a point, see [here](https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/ResultSetFuture.html)). This PR will cancel it if the Monix Task is cancelled.